### PR TITLE
Build theme bundle into dist directory

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+yarn.lock

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.5.tgz",
 			"integrity": "sha512-RhUPwaMmxWRTTKA3rO5gwRwRvoyVZNRsZMsQof852AwZq2bReUOYy4K9Ed6wF5SKQrJngVxNxiaGFddaZLLwSg==",
-			"dev": true,
 			"requires": {
 				"intersection-observer": "0.4.3",
 				"pepjs": "0.4.3",
@@ -16,14 +15,16 @@
 			}
 		},
 		"@dojo/webpack-contrib": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-0.1.6.tgz",
-			"integrity": "sha512-vBmLT8pgycXZEnMUFO+1ddSQLfUbh22EBl4ptklDUxQ8P4tK1Q2ckU8v32sFZ0BIDplWIfhmFNqxBLzcYZ8YlA==",
-			"dev": true,
+			"version": "file:../webpack-contrib/dist/dojo-webpack-contrib-0.1.7-rc.1.tgz",
+			"integrity": "sha1-LXf6yhVuZtoyyKe5Xd5lpUs2rWo=",
 			"requires": {
 				"@dojo/shim": "0.2.5",
+				"copy-webpack-plugin": "4.0.1",
+				"html-webpack-include-assets-plugin": "1.0.2",
 				"loader-utils": "1.1.0",
-				"recast": "0.12.9"
+				"recast": "0.12.9",
+				"ts-loader": "3.1.1",
+				"typed-css-modules": "0.3.1"
 			}
 		},
 		"@std/esm": {
@@ -93,20 +94,17 @@
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"dev": true
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-			"dev": true
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 		},
 		"anymatch": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-			"dev": true,
 			"requires": {
 				"micromatch": "2.3.11",
 				"normalize-path": "2.1.1"
@@ -131,7 +129,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-			"dev": true,
 			"requires": {
 				"arr-flatten": "1.1.0"
 			}
@@ -139,14 +136,12 @@
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-			"dev": true
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
 		},
 		"array-unique": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-			"dev": true
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
 		},
 		"asn1.js": {
 			"version": "4.9.2",
@@ -171,8 +166,7 @@
 		"ast-types": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
-			"integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ==",
-			"dev": true
+			"integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
 		},
 		"async": {
 			"version": "2.6.0",
@@ -186,8 +180,7 @@
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-			"dev": true
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
 		},
 		"autoprefixer": {
 			"version": "6.7.7",
@@ -239,14 +232,12 @@
 		"big.js": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-			"dev": true
+			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
 		},
 		"binary-extensions": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
-			"dev": true
+			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
 		},
 		"bluebird": {
 			"version": "3.5.1",
@@ -264,7 +255,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
@@ -273,8 +263,7 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"dev": true
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 				}
 			}
 		},
@@ -282,7 +271,6 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-			"dev": true,
 			"requires": {
 				"expand-range": "1.8.2",
 				"preserve": "0.2.0",
@@ -395,8 +383,7 @@
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-			"dev": true
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
 		},
 		"builtin-status-codes": {
 			"version": "3.0.0",
@@ -428,8 +415,7 @@
 		"camelcase": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-			"dev": true
+			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 		},
 		"caniuse-api": {
 			"version": "1.6.1",
@@ -469,7 +455,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "2.2.1",
 				"escape-string-regexp": "1.0.5",
@@ -482,7 +467,6 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-			"dev": true,
 			"requires": {
 				"anymatch": "1.3.2",
 				"async-each": "1.0.1",
@@ -524,7 +508,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-			"dev": true,
 			"requires": {
 				"string-width": "1.0.2",
 				"strip-ansi": "3.0.1",
@@ -535,7 +518,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -568,8 +550,7 @@
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"color": {
 			"version": "0.11.4",
@@ -586,7 +567,6 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -594,8 +574,7 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"color-string": {
 			"version": "0.3.0",
@@ -638,8 +617,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.0",
@@ -681,17 +659,73 @@
 				"run-queue": "1.0.3"
 			}
 		},
+		"copy-webpack-plugin": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.0.1.tgz",
+			"integrity": "sha1-lyjjg7lDFgUNDHRjlY8rhcCqggA=",
+			"requires": {
+				"bluebird": "2.11.0",
+				"fs-extra": "0.26.7",
+				"glob": "6.0.4",
+				"is-glob": "3.1.0",
+				"loader-utils": "0.2.17",
+				"lodash": "4.17.5",
+				"minimatch": "3.0.4",
+				"node-dir": "0.1.17"
+			},
+			"dependencies": {
+				"bluebird": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+					"integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+				},
+				"glob": {
+					"version": "6.0.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+					"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+					"requires": {
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+				},
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"requires": {
+						"is-extglob": "2.1.1"
+					}
+				},
+				"loader-utils": {
+					"version": "0.2.17",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+					"requires": {
+						"big.js": "3.2.0",
+						"emojis-list": "2.1.0",
+						"json5": "0.5.1",
+						"object-assign": "4.1.1"
+					}
+				}
+			}
+		},
 		"core-js": {
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
-			"dev": true
+			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cosmiconfig": {
 			"version": "2.2.2",
@@ -756,7 +790,6 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-			"dev": true,
 			"requires": {
 				"lru-cache": "4.1.1",
 				"shebang-command": "1.2.0",
@@ -834,7 +867,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/css-modules-loader-core/-/css-modules-loader-core-1.1.0.tgz",
 			"integrity": "sha1-WQhmgpShvs0mGuCkziGwtVHyHRY=",
-			"dev": true,
 			"requires": {
 				"icss-replace-symbols": "1.1.0",
 				"postcss": "6.0.1",
@@ -848,7 +880,6 @@
 					"version": "6.0.1",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
 					"integrity": "sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=",
-					"dev": true,
 					"requires": {
 						"chalk": "1.1.3",
 						"source-map": "0.5.7",
@@ -859,7 +890,6 @@
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
 					"requires": {
 						"has-flag": "1.0.0"
 					}
@@ -870,7 +900,6 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
 			"integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
-			"dev": true,
 			"requires": {
 				"cssesc": "0.1.0",
 				"fastparse": "1.1.1",
@@ -886,8 +915,7 @@
 		"cssesc": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
-			"dev": true
+			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
 		},
 		"cssnano": {
 			"version": "3.10.0",
@@ -972,8 +1000,7 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"defined": {
 			"version": "1.0.0",
@@ -1044,8 +1071,7 @@
 		"emojis-list": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-			"dev": true
+			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
 		},
 		"end-of-stream": {
 			"version": "1.4.1",
@@ -1060,7 +1086,6 @@
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
 			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"memory-fs": "0.4.1",
@@ -1072,7 +1097,6 @@
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
 			"integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
-			"dev": true,
 			"requires": {
 				"prr": "1.0.1"
 			}
@@ -1081,7 +1105,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-			"dev": true,
 			"requires": {
 				"is-arrayish": "0.2.1"
 			},
@@ -1089,8 +1112,7 @@
 				"is-arrayish": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-					"dev": true
+					"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 				}
 			}
 		},
@@ -1173,8 +1195,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escope": {
 			"version": "3.6.0",
@@ -1246,7 +1267,6 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-			"dev": true,
 			"requires": {
 				"cross-spawn": "5.1.0",
 				"get-stream": "3.0.0",
@@ -1261,7 +1281,6 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-			"dev": true,
 			"requires": {
 				"is-posix-bracket": "0.1.1"
 			}
@@ -1270,7 +1289,6 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"dev": true,
 			"requires": {
 				"fill-range": "2.2.3"
 			}
@@ -1279,7 +1297,6 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -1311,8 +1328,7 @@
 		"fastparse": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
-			"integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
-			"dev": true
+			"integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
 		},
 		"file-loader": {
 			"version": "1.1.5",
@@ -1327,14 +1343,12 @@
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-			"dev": true
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
 		},
 		"fill-range": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-			"dev": true,
 			"requires": {
 				"is-number": "2.1.0",
 				"isobject": "2.1.0",
@@ -1358,7 +1372,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-			"dev": true,
 			"requires": {
 				"locate-path": "2.0.0"
 			}
@@ -1382,14 +1395,12 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-			"dev": true
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true,
 			"requires": {
 				"for-in": "1.0.2"
 			}
@@ -1402,6 +1413,18 @@
 			"requires": {
 				"inherits": "2.0.3",
 				"readable-stream": "2.3.4"
+			}
+		},
+		"fs-extra": {
+			"version": "0.26.7",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+			"integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"jsonfile": "2.4.0",
+				"klaw": "1.3.1",
+				"path-is-absolute": "1.0.1",
+				"rimraf": "2.6.2"
 			}
 		},
 		"fs-write-stream-atomic": {
@@ -1419,14 +1442,12 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
 			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "2.8.0",
@@ -1437,14 +1458,12 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
 					"integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
-					"dev": true,
 					"optional": true
 				},
 				"ajv": {
 					"version": "4.11.8",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
 					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"co": "4.6.0",
@@ -1454,21 +1473,18 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"aproba": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
 					"integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
-					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
 					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "1.0.0",
@@ -1479,48 +1495,41 @@
 					"version": "0.2.3",
 					"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
 					"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-					"dev": true,
 					"optional": true
 				},
 				"assert-plus": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
 					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-					"dev": true,
 					"optional": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-					"dev": true,
 					"optional": true
 				},
 				"aws-sign2": {
 					"version": "0.6.0",
 					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
 					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-					"dev": true,
 					"optional": true
 				},
 				"aws4": {
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
 					"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-					"dev": true,
 					"optional": true
 				},
 				"balanced-match": {
 					"version": "0.4.2",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-					"dev": true
+					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 					"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"tweetnacl": "0.14.5"
@@ -1530,7 +1539,6 @@
 					"version": "0.0.9",
 					"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
 					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-					"dev": true,
 					"requires": {
 						"inherits": "2.0.3"
 					}
@@ -1539,7 +1547,6 @@
 					"version": "2.10.1",
 					"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
 					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -1548,7 +1555,6 @@
 					"version": "1.1.7",
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
 					"integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-					"dev": true,
 					"requires": {
 						"balanced-match": "0.4.2",
 						"concat-map": "0.0.1"
@@ -1557,34 +1563,29 @@
 				"buffer-shims": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-					"integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-					"dev": true
+					"integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
 				},
 				"caseless": {
 					"version": "0.12.0",
 					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-					"dev": true,
 					"optional": true
 				},
 				"co": {
 					"version": "4.6.0",
 					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
 					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-					"dev": true
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 				},
 				"combined-stream": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
 					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-					"dev": true,
 					"requires": {
 						"delayed-stream": "1.0.0"
 					}
@@ -1592,26 +1593,22 @@
 				"concat-map": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"dev": true
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-					"dev": true
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 				},
 				"core-util-is": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-					"dev": true
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 				},
 				"cryptiles": {
 					"version": "2.0.5",
 					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-					"dev": true,
 					"requires": {
 						"boom": "2.10.1"
 					}
@@ -1620,7 +1617,6 @@
 					"version": "1.14.1",
 					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -1630,7 +1626,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -1639,7 +1634,6 @@
 					"version": "2.6.8",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
 					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -1649,34 +1643,29 @@
 					"version": "0.4.2",
 					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
 					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-					"dev": true,
 					"optional": true
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-					"dev": true
+					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
 					"integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
-					"dev": true,
 					"optional": true
 				},
 				"ecc-jsbn": {
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 					"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -1686,27 +1675,23 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
 					"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-					"dev": true,
 					"optional": true
 				},
 				"extsprintf": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-					"integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-					"dev": true
+					"integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
 				},
 				"forever-agent": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
 					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-					"dev": true,
 					"optional": true
 				},
 				"form-data": {
 					"version": "2.1.4",
 					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
 					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"asynckit": "0.4.0",
@@ -1717,14 +1702,12 @@
 				"fs.realpath": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-					"dev": true
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 				},
 				"fstream": {
 					"version": "1.0.11",
 					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
 					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"inherits": "2.0.3",
@@ -1736,7 +1719,6 @@
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
 					"integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"fstream": "1.0.11",
@@ -1748,7 +1730,6 @@
 					"version": "2.7.4",
 					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "1.1.1",
@@ -1765,7 +1746,6 @@
 					"version": "0.1.7",
 					"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0"
@@ -1775,7 +1755,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -1784,7 +1763,6 @@
 					"version": "7.1.2",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
 						"inflight": "1.0.6",
@@ -1797,21 +1775,18 @@
 				"graceful-fs": {
 					"version": "4.1.11",
 					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-					"dev": true
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
 				},
 				"har-schema": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
 					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-					"dev": true,
 					"optional": true
 				},
 				"har-validator": {
 					"version": "4.2.1",
 					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
 					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"ajv": "4.11.8",
@@ -1822,14 +1797,12 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-					"dev": true,
 					"optional": true
 				},
 				"hawk": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
 					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-					"dev": true,
 					"requires": {
 						"boom": "2.10.1",
 						"cryptiles": "2.0.5",
@@ -1840,14 +1813,12 @@
 				"hoek": {
 					"version": "2.16.3",
 					"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-					"dev": true
+					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
 				},
 				"http-signature": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
 					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "0.2.0",
@@ -1859,7 +1830,6 @@
 					"version": "1.0.6",
 					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-					"dev": true,
 					"requires": {
 						"once": "1.4.0",
 						"wrappy": "1.0.2"
@@ -1868,21 +1838,18 @@
 				"inherits": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"dev": true
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 				},
 				"ini": {
 					"version": "1.3.4",
 					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
 					"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -1891,27 +1858,23 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-					"dev": true,
 					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"isstream": {
 					"version": "0.1.2",
 					"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-					"dev": true,
 					"optional": true
 				},
 				"jodid25519": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
 					"integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsbn": "0.1.1"
@@ -1921,21 +1884,18 @@
 					"version": "0.1.1",
 					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-					"dev": true,
 					"optional": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
 					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
 					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-					"dev": true,
 					"optional": true
 				},
 				"json-stable-stringify": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 					"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"jsonify": "0.0.0"
@@ -1945,21 +1905,18 @@
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-					"dev": true,
 					"optional": true
 				},
 				"jsonify": {
 					"version": "0.0.0",
 					"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
 					"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-					"dev": true,
 					"optional": true
 				},
 				"jsprim": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
 					"integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"assert-plus": "1.0.0",
@@ -1972,7 +1929,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -1980,14 +1936,12 @@
 				"mime-db": {
 					"version": "1.27.0",
 					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-					"integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-					"dev": true
+					"integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
 				},
 				"mime-types": {
 					"version": "2.1.15",
 					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
 					"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-					"dev": true,
 					"requires": {
 						"mime-db": "1.27.0"
 					}
@@ -1996,7 +1950,6 @@
 					"version": "3.0.4",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.7"
 					}
@@ -2004,14 +1957,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2020,14 +1971,12 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true,
 					"optional": true
 				},
 				"node-pre-gyp": {
 					"version": "0.6.39",
 					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
 					"integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "1.0.2",
@@ -2047,7 +1996,6 @@
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1.1.0",
@@ -2058,7 +2006,6 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
 					"integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "1.1.4",
@@ -2070,28 +2017,24 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-					"dev": true
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 				},
 				"oauth-sign": {
 					"version": "0.8.2",
 					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
 					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -2100,21 +2043,18 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
 					"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "1.0.2",
@@ -2124,41 +2064,35 @@
 				"path-is-absolute": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-					"dev": true
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 				},
 				"performance-now": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
 					"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
 					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-					"dev": true
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
 				},
 				"punycode": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true,
 					"optional": true
 				},
 				"qs": {
 					"version": "6.4.0",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
 					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
 					"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "0.4.2",
@@ -2171,7 +2105,6 @@
 							"version": "1.2.0",
 							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -2180,7 +2113,6 @@
 					"version": "2.2.9",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
 					"integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-					"dev": true,
 					"requires": {
 						"buffer-shims": "1.0.0",
 						"core-util-is": "1.0.2",
@@ -2195,7 +2127,6 @@
 					"version": "2.81.0",
 					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
 					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"aws-sign2": "0.6.0",
@@ -2226,7 +2157,6 @@
 					"version": "2.6.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 					"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
 					}
@@ -2234,35 +2164,30 @@
 				"safe-buffer": {
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-					"integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-					"dev": true
+					"integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
 				},
 				"semver": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
 					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-					"dev": true,
 					"optional": true
 				},
 				"sntp": {
 					"version": "1.0.9",
 					"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
 					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
 					}
@@ -2271,7 +2196,6 @@
 					"version": "1.13.0",
 					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
 					"integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"asn1": "0.2.3",
@@ -2289,7 +2213,6 @@
 							"version": "1.0.0",
 							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-							"dev": true,
 							"optional": true
 						}
 					}
@@ -2298,7 +2221,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -2309,7 +2231,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
 					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
 					}
@@ -2318,14 +2239,12 @@
 					"version": "0.0.5",
 					"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
 					"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-					"dev": true,
 					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -2334,14 +2253,12 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
 					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-					"dev": true,
 					"requires": {
 						"block-stream": "0.0.9",
 						"fstream": "1.0.11",
@@ -2352,7 +2269,6 @@
 					"version": "3.4.0",
 					"resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
 					"integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "2.6.8",
@@ -2369,7 +2285,6 @@
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
 					"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"punycode": "1.4.1"
@@ -2379,7 +2294,6 @@
 					"version": "0.6.0",
 					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
@@ -2389,34 +2303,29 @@
 					"version": "0.14.5",
 					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-					"dev": true,
 					"optional": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
 					"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
 					"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-					"dev": true,
 					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-					"dev": true
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 				},
 				"uuid": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
 					"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-					"dev": true,
 					"optional": true
 				},
 				"verror": {
 					"version": "1.3.6",
 					"resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
 					"integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"extsprintf": "1.0.2"
@@ -2426,7 +2335,6 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
 					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "1.0.2"
@@ -2435,8 +2343,7 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"dev": true
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 				}
 			}
 		},
@@ -2449,20 +2356,17 @@
 		"get-caller-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-			"dev": true
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
 		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-			"dev": true
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 		},
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
@@ -2476,7 +2380,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true,
 			"requires": {
 				"glob-parent": "2.0.0",
 				"is-glob": "2.0.1"
@@ -2486,7 +2389,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"dev": true,
 			"requires": {
 				"is-glob": "2.0.1"
 			}
@@ -2494,8 +2396,7 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-			"dev": true
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
 		},
 		"has": {
 			"version": "1.0.1",
@@ -2510,7 +2411,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -2518,8 +2418,7 @@
 		"has-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-			"dev": true
+			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
 		},
 		"hash-base": {
 			"version": "2.0.2",
@@ -2554,14 +2453,23 @@
 		"hosted-git-info": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-			"dev": true
+			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
 		},
 		"html-comment-regex": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
 			"integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
 			"dev": true
+		},
+		"html-webpack-include-assets-plugin": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/html-webpack-include-assets-plugin/-/html-webpack-include-assets-plugin-1.0.2.tgz",
+			"integrity": "sha512-e9ck8RWk+z6aV2XThCCpV/Cn8wK0SWoi8K7b1ZnOP9BSckh3z9/NFoWFc453aywCsyq8RQGhAPx/BOHpaACqkA==",
+			"requires": {
+				"glob": "7.1.2",
+				"minimatch": "3.0.4",
+				"slash": "1.0.0"
+			}
 		},
 		"https-browserify": {
 			"version": "1.0.0",
@@ -2572,8 +2480,7 @@
 		"icss-replace-symbols": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
-			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
-			"dev": true
+			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
 		},
 		"icss-utils": {
 			"version": "2.1.0",
@@ -2682,7 +2589,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "1.4.0",
 				"wrappy": "1.0.2"
@@ -2691,8 +2597,7 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-			"dev": true
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"interpret": {
 			"version": "1.1.0",
@@ -2703,14 +2608,12 @@
 		"intersection-observer": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.4.3.tgz",
-			"integrity": "sha512-sRobbVo/+DVGkbco/UkuREmXSr5ypWeQ7S7tYDhzIIP3NFtAHLkkFYdivFAIgNe4sfDYBFAjxEgUyxiEmA/dgQ==",
-			"dev": true
+			"integrity": "sha512-sRobbVo/+DVGkbco/UkuREmXSr5ypWeQ7S7tYDhzIIP3NFtAHLkkFYdivFAIgNe4sfDYBFAjxEgUyxiEmA/dgQ=="
 		},
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-			"dev": true
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 		},
 		"is-absolute-url": {
 			"version": "2.1.0",
@@ -2728,7 +2631,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-			"dev": true,
 			"requires": {
 				"binary-extensions": "1.11.0"
 			}
@@ -2736,14 +2638,12 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"dev": true,
 			"requires": {
 				"builtin-modules": "1.1.1"
 			}
@@ -2757,14 +2657,12 @@
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"dev": true
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"dev": true,
 			"requires": {
 				"is-primitive": "2.0.0"
 			}
@@ -2772,20 +2670,17 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-			"dev": true
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-			"dev": true
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 		},
 		"is-fullwidth-code-point": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -2794,7 +2689,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -2803,7 +2697,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2"
 			}
@@ -2817,20 +2710,17 @@
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-			"dev": true
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"dev": true
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
 		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-svg": {
 			"version": "2.1.0",
@@ -2844,20 +2734,17 @@
 		"is-there": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/is-there/-/is-there-4.4.3.tgz",
-			"integrity": "sha1-osSTZsakh/cZ28rYDL3iEkjSwY0=",
-			"dev": true
+			"integrity": "sha1-osSTZsakh/cZ28rYDL3iEkjSwY0="
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isnumeric": {
 			"version": "0.2.0",
@@ -2869,7 +2756,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-			"dev": true,
 			"requires": {
 				"isarray": "1.0.0"
 			}
@@ -2899,8 +2785,7 @@
 		"jsesc": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-			"dev": true
+			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 		},
 		"json-css-module-loader": {
 			"version": "1.0.2",
@@ -2923,16 +2808,30 @@
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-			"dev": true
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+		},
+		"jsonfile": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+			"requires": {
+				"graceful-fs": "4.1.11"
+			}
 		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-			"dev": true,
 			"requires": {
 				"is-buffer": "1.1.6"
+			}
+		},
+		"klaw": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+			"requires": {
+				"graceful-fs": "4.1.11"
 			}
 		},
 		"lazy-cache": {
@@ -2945,7 +2844,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-			"dev": true,
 			"requires": {
 				"invert-kv": "1.0.0"
 			}
@@ -2954,7 +2852,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"parse-json": "2.2.0",
@@ -2972,7 +2869,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-			"dev": true,
 			"requires": {
 				"big.js": "3.2.0",
 				"emojis-list": "2.1.0",
@@ -2983,7 +2879,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-			"dev": true,
 			"requires": {
 				"p-locate": "2.0.0",
 				"path-exists": "3.0.0"
@@ -2992,8 +2887,7 @@
 		"lodash": {
 			"version": "4.17.5",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-			"dev": true
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
@@ -3048,7 +2942,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-			"dev": true,
 			"requires": {
 				"pseudomap": "1.0.2",
 				"yallist": "2.1.2"
@@ -3109,7 +3002,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-			"dev": true,
 			"requires": {
 				"mimic-fn": "1.2.0"
 			}
@@ -3118,7 +3010,6 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-			"dev": true,
 			"requires": {
 				"errno": "0.1.6",
 				"readable-stream": "2.3.4"
@@ -3128,7 +3019,6 @@
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-			"dev": true,
 			"requires": {
 				"arr-diff": "2.0.0",
 				"array-unique": "0.2.1",
@@ -3158,8 +3048,7 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-			"dev": true
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
 		},
 		"minimalistic-assert": {
 			"version": "1.0.0",
@@ -3177,7 +3066,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "1.1.11"
 			}
@@ -3185,8 +3073,7 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"mississippi": {
 			"version": "1.3.1",
@@ -3210,7 +3097,6 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -3239,8 +3125,15 @@
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
 			"integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-			"dev": true,
 			"optional": true
+		},
+		"node-dir": {
+			"version": "0.1.17",
+			"resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+			"integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+			"requires": {
+				"minimatch": "3.0.4"
+			}
 		},
 		"node-libs-browser": {
 			"version": "2.1.0",
@@ -3277,7 +3170,6 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-			"dev": true,
 			"requires": {
 				"hosted-git-info": "2.5.0",
 				"is-builtin-module": "1.0.0",
@@ -3289,7 +3181,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "1.1.0"
 			}
@@ -3316,7 +3207,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"dev": true,
 			"requires": {
 				"path-key": "2.0.1"
 			}
@@ -3330,20 +3220,17 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object.omit": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"dev": true,
 			"requires": {
 				"for-own": "0.1.5",
 				"is-extendable": "0.1.1"
@@ -3353,7 +3240,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1.0.2"
 			}
@@ -3380,7 +3266,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-			"dev": true,
 			"requires": {
 				"execa": "0.7.0",
 				"lcid": "1.0.0",
@@ -3390,14 +3275,12 @@
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-limit": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
 			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-			"dev": true,
 			"requires": {
 				"p-try": "1.0.0"
 			}
@@ -3406,7 +3289,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-			"dev": true,
 			"requires": {
 				"p-limit": "1.2.0"
 			}
@@ -3414,8 +3296,7 @@
 		"p-try": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-			"dev": true
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 		},
 		"pako": {
 			"version": "1.0.6",
@@ -3451,7 +3332,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"dev": true,
 			"requires": {
 				"glob-base": "0.3.0",
 				"is-dotfile": "1.0.3",
@@ -3463,7 +3343,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-			"dev": true,
 			"requires": {
 				"error-ex": "1.3.1"
 			}
@@ -3477,20 +3356,17 @@
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-			"dev": true
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 		},
 		"path-parse": {
 			"version": "1.0.5",
@@ -3502,7 +3378,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-			"dev": true,
 			"requires": {
 				"pify": "2.3.0"
 			}
@@ -3523,14 +3398,12 @@
 		"pepjs": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/pepjs/-/pepjs-0.4.3.tgz",
-			"integrity": "sha1-FggOlwqud5kTdWwtrviOqnSG30E=",
-			"dev": true
+			"integrity": "sha1-FggOlwqud5kTdWwtrviOqnSG30E="
 		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-			"dev": true
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 		},
 		"pixrem": {
 			"version": "4.0.1",
@@ -5386,7 +5259,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
 			"integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
-			"dev": true,
 			"requires": {
 				"postcss": "6.0.17"
 			},
@@ -5395,7 +5267,6 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -5404,7 +5275,6 @@
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.0",
 						"escape-string-regexp": "1.0.5",
@@ -5414,14 +5284,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"postcss": {
 					"version": "6.0.17",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
 					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
-					"dev": true,
 					"requires": {
 						"chalk": "2.3.1",
 						"source-map": "0.6.1",
@@ -5431,14 +5299,12 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"supports-color": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -5449,7 +5315,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
 			"integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
-			"dev": true,
 			"requires": {
 				"css-selector-tokenizer": "0.7.0",
 				"postcss": "6.0.17"
@@ -5459,7 +5324,6 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -5468,7 +5332,6 @@
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.0",
 						"escape-string-regexp": "1.0.5",
@@ -5478,14 +5341,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"postcss": {
 					"version": "6.0.17",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
 					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
-					"dev": true,
 					"requires": {
 						"chalk": "2.3.1",
 						"source-map": "0.6.1",
@@ -5495,14 +5356,12 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"supports-color": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -5513,7 +5372,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
 			"integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
-			"dev": true,
 			"requires": {
 				"css-selector-tokenizer": "0.7.0",
 				"postcss": "6.0.17"
@@ -5523,7 +5381,6 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -5532,7 +5389,6 @@
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.0",
 						"escape-string-regexp": "1.0.5",
@@ -5542,14 +5398,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"postcss": {
 					"version": "6.0.17",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
 					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
-					"dev": true,
 					"requires": {
 						"chalk": "2.3.1",
 						"source-map": "0.6.1",
@@ -5559,14 +5413,12 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"supports-color": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -5577,7 +5429,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
 			"integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
-			"dev": true,
 			"requires": {
 				"icss-replace-symbols": "1.1.0",
 				"postcss": "6.0.17"
@@ -5587,7 +5438,6 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -5596,7 +5446,6 @@
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.0",
 						"escape-string-regexp": "1.0.5",
@@ -5606,14 +5455,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"postcss": {
 					"version": "6.0.17",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
 					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
-					"dev": true,
 					"requires": {
 						"chalk": "2.3.1",
 						"source-map": "0.6.1",
@@ -5623,14 +5470,12 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"supports-color": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -6139,14 +5984,12 @@
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-			"dev": true
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
 		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-			"dev": true
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
 		},
 		"process": {
 			"version": "0.11.10",
@@ -6157,8 +6000,7 @@
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-			"dev": true
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"promise-inflight": {
 			"version": "1.0.1",
@@ -6169,14 +6011,12 @@
 		"prr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-			"dev": true
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"public-encrypt": {
 			"version": "4.0.0",
@@ -6262,7 +6102,6 @@
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-			"dev": true,
 			"requires": {
 				"is-number": "3.0.0",
 				"kind-of": "4.0.0"
@@ -6272,7 +6111,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -6281,7 +6119,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.6"
 							}
@@ -6292,7 +6129,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.6"
 					}
@@ -6331,7 +6167,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-			"dev": true,
 			"requires": {
 				"load-json-file": "2.0.0",
 				"normalize-package-data": "2.4.0",
@@ -6342,7 +6177,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-			"dev": true,
 			"requires": {
 				"find-up": "2.1.0",
 				"read-pkg": "2.0.0"
@@ -6352,7 +6186,6 @@
 			"version": "2.3.4",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
 			"integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
-			"dev": true,
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
@@ -6367,7 +6200,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"minimatch": "3.0.4",
@@ -6379,7 +6211,6 @@
 			"version": "0.12.9",
 			"resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
 			"integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
-			"dev": true,
 			"requires": {
 				"ast-types": "0.10.1",
 				"core-js": "2.5.3",
@@ -6391,14 +6222,12 @@
 				"esprima": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-					"dev": true
+					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -6434,8 +6263,7 @@
 		"regenerate": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
-			"dev": true
+			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
 		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
@@ -6447,7 +6275,6 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-			"dev": true,
 			"requires": {
 				"is-equal-shallow": "0.1.3"
 			}
@@ -6456,7 +6283,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
 			"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-			"dev": true,
 			"requires": {
 				"regenerate": "1.3.3",
 				"regjsgen": "0.2.0",
@@ -6466,14 +6292,12 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-			"dev": true
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-			"dev": true,
 			"requires": {
 				"jsesc": "0.5.0"
 			}
@@ -6481,26 +6305,22 @@
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"dev": true
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-			"dev": true
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"require-from-string": {
 			"version": "1.2.1",
@@ -6511,8 +6331,7 @@
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-			"dev": true
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"resolve": {
 			"version": "1.5.0",
@@ -6548,7 +6367,6 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-			"dev": true,
 			"requires": {
 				"glob": "7.1.2"
 			}
@@ -6575,8 +6393,7 @@
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-			"dev": true
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
 		},
 		"sax": {
 			"version": "1.2.4",
@@ -6596,20 +6413,17 @@
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-			"dev": true
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
 		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-			"dev": true
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
 		},
 		"setimmediate": {
 			"version": "1.0.5",
@@ -6631,7 +6445,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"dev": true,
 			"requires": {
 				"shebang-regex": "1.0.0"
 			}
@@ -6639,8 +6452,7 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-			"dev": true
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
 		"shelljs": {
 			"version": "0.7.8",
@@ -6675,8 +6487,7 @@
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-			"dev": true
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"simple-swizzle": {
 			"version": "0.2.2",
@@ -6690,8 +6501,7 @@
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-			"dev": true
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 		},
 		"sort-keys": {
 			"version": "1.1.2",
@@ -6711,14 +6521,12 @@
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-			"dev": true
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
 		"spdx-correct": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-			"dev": true,
 			"requires": {
 				"spdx-license-ids": "1.2.2"
 			}
@@ -6726,14 +6534,12 @@
 		"spdx-expression-parse": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-			"dev": true
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
 		},
 		"spdx-license-ids": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-			"dev": true
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
@@ -6799,7 +6605,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0",
 				"strip-ansi": "4.0.0"
@@ -6808,20 +6613,17 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -6832,7 +6634,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -6841,7 +6642,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -6849,14 +6649,12 @@
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-			"dev": true
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 		},
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-			"dev": true
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"style-loader": {
 			"version": "0.19.0",
@@ -6871,8 +6669,7 @@
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-			"dev": true
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 		},
 		"svgo": {
 			"version": "0.7.2",
@@ -6892,8 +6689,7 @@
 		"tapable": {
 			"version": "0.2.8",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
-			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
-			"dev": true
+			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
 		},
 		"through2": {
 			"version": "2.0.3",
@@ -6924,7 +6720,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-3.1.1.tgz",
 			"integrity": "sha512-AQmLFSIgTiR8AlS5BxqvoHpZ3OUTwHHuDZTAZ2KcKsYRz/yANGeQn4Se/DCQ4cn1/eVvN37f/caVW4+kUPNNHw==",
-			"dev": true,
 			"requires": {
 				"chalk": "2.3.1",
 				"enhanced-resolve": "3.4.1",
@@ -6936,7 +6731,6 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -6945,7 +6739,6 @@
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.0",
 						"escape-string-regexp": "1.0.5",
@@ -6955,14 +6748,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -6972,8 +6763,7 @@
 		"tslib": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
-			"dev": true
+			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
 		},
 		"tty-browserify": {
 			"version": "0.0.0",
@@ -6985,7 +6775,6 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/typed-css-modules/-/typed-css-modules-0.3.1.tgz",
 			"integrity": "sha512-RHIKxvl9ytIGM1H13dFTJI44EslhMAZQobY6Do8EIy7JsZI65REQ+N5NHInyOAfvnEWmhIaMrlrDGdLFFIRGow==",
-			"dev": true,
 			"requires": {
 				"camelcase": "4.1.0",
 				"chalk": "2.3.1",
@@ -7001,7 +6790,6 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -7010,7 +6798,6 @@
 					"version": "2.3.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
 					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.0",
 						"escape-string-regexp": "1.0.5",
@@ -7020,14 +6807,12 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
 					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
-					"dev": true,
 					"requires": {
 						"has-flag": "3.0.0"
 					}
@@ -7181,14 +6966,12 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-			"dev": true,
 			"requires": {
 				"spdx-correct": "1.0.2",
 				"spdx-expression-parse": "1.0.4"
@@ -7354,7 +7137,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-			"dev": true,
 			"requires": {
 				"isexe": "2.0.0"
 			}
@@ -7362,8 +7144,7 @@
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-			"dev": true
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
 		"window-size": {
 			"version": "0.1.0",
@@ -7391,7 +7172,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-			"dev": true,
 			"requires": {
 				"string-width": "1.0.2",
 				"strip-ansi": "3.0.1"
@@ -7401,7 +7181,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -7413,8 +7192,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"xtend": {
 			"version": "4.0.1",
@@ -7425,20 +7203,17 @@
 		"y18n": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-			"dev": true
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 		},
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-			"dev": true
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
 			"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-			"dev": true,
 			"requires": {
 				"camelcase": "4.1.0",
 				"cliui": "3.2.0",
@@ -7459,7 +7234,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
 			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-			"dev": true,
 			"requires": {
 				"camelcase": "4.1.0"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,92 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@dojo/shim": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.5.tgz",
+			"integrity": "sha512-RhUPwaMmxWRTTKA3rO5gwRwRvoyVZNRsZMsQof852AwZq2bReUOYy4K9Ed6wF5SKQrJngVxNxiaGFddaZLLwSg==",
+			"dev": true,
+			"requires": {
+				"intersection-observer": "0.4.3",
+				"pepjs": "0.4.3",
+				"tslib": "1.9.0"
+			}
+		},
+		"@dojo/webpack-contrib": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-0.1.6.tgz",
+			"integrity": "sha512-vBmLT8pgycXZEnMUFO+1ddSQLfUbh22EBl4ptklDUxQ8P4tK1Q2ckU8v32sFZ0BIDplWIfhmFNqxBLzcYZ8YlA==",
+			"dev": true,
+			"requires": {
+				"@dojo/shim": "0.2.5",
+				"loader-utils": "1.1.0",
+				"recast": "0.12.9"
+			}
+		},
+		"@std/esm": {
+			"version": "0.19.7",
+			"resolved": "https://registry.npmjs.org/@std/esm/-/esm-0.19.7.tgz",
+			"integrity": "sha512-bPBbpu1vqgOOD70aMVG5tgioPdttKXQQFq6xodjZxVbPprtZIcm8NcTEJoB+/1QoH8z1TIqjaEN1Wm3YndnfNQ==",
+			"dev": true
+		},
+		"acorn": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+			"integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+			"dev": true
+		},
+		"acorn-dynamic-import": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+			"dev": true,
+			"requires": {
+				"acorn": "4.0.13"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "4.0.13",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+					"dev": true
+				}
+			}
+		},
+		"ajv": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"dev": true,
+			"requires": {
+				"co": "4.6.0",
+				"fast-deep-equal": "1.0.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
+			}
+		},
+		"ajv-keywords": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+			"dev": true
+		},
+		"align-text": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"alphanum-sort": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+			"dev": true
+		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -11,13 +97,10 @@
 			"dev": true
 		},
 		"ansi-styles": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-			"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-			"dev": true,
-			"requires": {
-				"color-convert": "1.9.1"
-			}
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
 		},
 		"anymatch": {
 			"version": "1.3.2",
@@ -27,6 +110,21 @@
 			"requires": {
 				"micromatch": "2.3.11",
 				"normalize-path": "2.1.1"
+			}
+		},
+		"aproba": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true
+		},
+		"argparse": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "1.0.3"
 			}
 		},
 		"arr-diff": {
@@ -50,16 +148,98 @@
 			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
 			"dev": true
 		},
+		"asn1.js": {
+			"version": "4.9.2",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
+			"integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+			"dev": true,
+			"requires": {
+				"bn.js": "4.11.8",
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0"
+			}
+		},
+		"assert": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+			"dev": true,
+			"requires": {
+				"util": "0.10.3"
+			}
+		},
+		"ast-types": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
+			"integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ==",
+			"dev": true
+		},
+		"async": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+			"dev": true,
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
 			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
 			"dev": true
 		},
+		"autoprefixer": {
+			"version": "6.7.7",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+			"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+			"dev": true,
+			"requires": {
+				"browserslist": "1.7.7",
+				"caniuse-db": "1.0.30000808",
+				"normalize-range": "0.1.2",
+				"num2fraction": "1.2.2",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			}
+		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
+			"requires": {
+				"core-js": "2.5.3",
+				"regenerator-runtime": "0.11.1"
+			}
+		},
 		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+			"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+			"dev": true
+		},
+		"base64-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+			"integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+			"dev": true
+		},
+		"big.js": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
 			"dev": true
 		},
 		"binary-extensions": {
@@ -68,14 +248,34 @@
 			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
 			"dev": true
 		},
+		"bluebird": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+			"dev": true
+		},
+		"bn.js": {
+			"version": "4.11.8",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+			"dev": true
+		},
 		"brace-expansion": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
+			},
+			"dependencies": {
+				"balanced-match": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+					"dev": true
+				}
 			}
 		},
 		"braces": {
@@ -89,11 +289,141 @@
 				"repeat-element": "1.1.2"
 			}
 		},
+		"brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+			"dev": true
+		},
+		"browserify-aes": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
+			"integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+			"dev": true,
+			"requires": {
+				"buffer-xor": "1.0.3",
+				"cipher-base": "1.0.4",
+				"create-hash": "1.1.3",
+				"evp_bytestokey": "1.0.3",
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"browserify-cipher": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+			"dev": true,
+			"requires": {
+				"browserify-aes": "1.1.1",
+				"browserify-des": "1.0.0",
+				"evp_bytestokey": "1.0.3"
+			}
+		},
+		"browserify-des": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+			"dev": true,
+			"requires": {
+				"cipher-base": "1.0.4",
+				"des.js": "1.0.0",
+				"inherits": "2.0.3"
+			}
+		},
+		"browserify-rsa": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+			"dev": true,
+			"requires": {
+				"bn.js": "4.11.8",
+				"randombytes": "2.0.6"
+			}
+		},
+		"browserify-sign": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+			"dev": true,
+			"requires": {
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.1.3",
+				"create-hmac": "1.1.6",
+				"elliptic": "6.4.0",
+				"inherits": "2.0.3",
+				"parse-asn1": "5.1.0"
+			}
+		},
+		"browserify-zlib": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+			"dev": true,
+			"requires": {
+				"pako": "1.0.6"
+			}
+		},
+		"browserslist": {
+			"version": "1.7.7",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+			"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+			"dev": true,
+			"requires": {
+				"caniuse-db": "1.0.30000808",
+				"electron-to-chromium": "1.3.33"
+			}
+		},
+		"buffer": {
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+			"dev": true,
+			"requires": {
+				"base64-js": "1.2.1",
+				"ieee754": "1.1.8",
+				"isarray": "1.0.0"
+			}
+		},
+		"buffer-xor": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+			"dev": true
+		},
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
 			"dev": true
+		},
+		"builtin-status-codes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+			"dev": true
+		},
+		"cacache": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.2.tgz",
+			"integrity": "sha512-dljb7dk1jqO5ogE+dRpoR9tpHYv5xz9vPSNunh1+0wRuNdYxmzp9WmsyokgW/DUF1FDRVA/TMsmxt027R8djbQ==",
+			"dev": true,
+			"requires": {
+				"bluebird": "3.5.1",
+				"chownr": "1.0.1",
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"lru-cache": "4.1.1",
+				"mississippi": "1.3.1",
+				"mkdirp": "0.5.1",
+				"move-concurrently": "1.0.1",
+				"promise-inflight": "1.0.1",
+				"rimraf": "2.6.2",
+				"ssri": "5.2.1",
+				"unique-filename": "1.1.0",
+				"y18n": "3.2.1"
+			}
 		},
 		"camelcase": {
 			"version": "4.1.0",
@@ -101,15 +431,51 @@
 			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
 			"dev": true
 		},
-		"chalk": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-			"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+		"caniuse-api": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+			"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.0",
+				"browserslist": "1.7.7",
+				"caniuse-db": "1.0.30000808",
+				"lodash.memoize": "4.1.2",
+				"lodash.uniq": "4.5.0"
+			}
+		},
+		"caniuse-db": {
+			"version": "1.0.30000808",
+			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000808.tgz",
+			"integrity": "sha1-MN/YMAnVcE8C3/s3clBo7RKjZrs=",
+			"dev": true
+		},
+		"caniuse-lite": {
+			"version": "1.0.30000808",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000808.tgz",
+			"integrity": "sha512-vT0JLmHdvq1UVbYXioxCXHYdNw55tyvi+IUWyX0Zeh1OFQi2IllYtm38IJnSgHWCv/zUnX1hdhy3vMJvuTNSqw==",
+			"dev": true
+		},
+		"center-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"dev": true,
+			"requires": {
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
+			}
+		},
+		"chalk": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "2.2.1",
 				"escape-string-regexp": "1.0.5",
-				"supports-color": "4.5.0"
+				"has-ansi": "2.0.0",
+				"strip-ansi": "3.0.1",
+				"supports-color": "2.0.0"
 			}
 		},
 		"chokidar": {
@@ -127,6 +493,31 @@
 				"is-glob": "2.0.1",
 				"path-is-absolute": "1.0.1",
 				"readdirp": "2.1.0"
+			}
+		},
+		"chownr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+			"dev": true
+		},
+		"cipher-base": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"clap": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+			"integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3"
 			}
 		},
 		"cliui": {
@@ -153,11 +544,43 @@
 				}
 			}
 		},
+		"clone": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+			"integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+			"dev": true
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
+		},
+		"coa": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+			"integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+			"dev": true,
+			"requires": {
+				"q": "1.5.1"
+			}
+		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 			"dev": true
+		},
+		"color": {
+			"version": "0.11.4",
+			"resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+			"dev": true,
+			"requires": {
+				"clone": "1.0.3",
+				"color-convert": "1.9.1",
+				"color-string": "0.3.0"
+			}
 		},
 		"color-convert": {
 			"version": "1.9.1",
@@ -174,10 +597,94 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
 		},
+		"color-string": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"colormin": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+			"integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
+			"dev": true,
+			"requires": {
+				"color": "0.11.4",
+				"css-color-names": "0.0.4",
+				"has": "1.0.1"
+			}
+		},
+		"colors": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+			"dev": true
+		},
+		"commander": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+			"integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+			"dev": true
+		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+			"dev": true
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"concat-stream": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.4",
+				"typedarray": "0.0.6"
+			}
+		},
+		"console-browserify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+			"dev": true,
+			"requires": {
+				"date-now": "0.1.4"
+			}
+		},
+		"constants-browserify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+			"dev": true
+		},
+		"copy-concurrently": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+			"dev": true,
+			"requires": {
+				"aproba": "1.2.0",
+				"fs-write-stream-atomic": "1.0.10",
+				"iferr": "0.1.5",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"run-queue": "1.0.3"
+			}
+		},
+		"core-js": {
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
 			"dev": true
 		},
 		"core-util-is": {
@@ -185,6 +692,65 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true
+		},
+		"cosmiconfig": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+			"integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
+			"dev": true,
+			"requires": {
+				"is-directory": "0.3.1",
+				"js-yaml": "3.7.0",
+				"minimist": "1.2.0",
+				"object-assign": "4.1.1",
+				"os-homedir": "1.0.2",
+				"parse-json": "2.2.0",
+				"require-from-string": "1.2.1"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
+			}
+		},
+		"create-ecdh": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+			"dev": true,
+			"requires": {
+				"bn.js": "4.11.8",
+				"elliptic": "6.4.0"
+			}
+		},
+		"create-hash": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+			"dev": true,
+			"requires": {
+				"cipher-base": "1.0.4",
+				"inherits": "2.0.3",
+				"ripemd160": "2.0.1",
+				"sha.js": "2.4.10"
+			}
+		},
+		"create-hmac": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+			"dev": true,
+			"requires": {
+				"cipher-base": "1.0.4",
+				"create-hash": "1.1.3",
+				"inherits": "2.0.3",
+				"ripemd160": "2.0.1",
+				"safe-buffer": "5.1.1",
+				"sha.js": "2.4.10"
+			}
 		},
 		"cross-spawn": {
 			"version": "5.1.0",
@@ -195,6 +761,73 @@
 				"lru-cache": "4.1.1",
 				"shebang-command": "1.2.0",
 				"which": "1.3.0"
+			}
+		},
+		"crypto-browserify": {
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+			"dev": true,
+			"requires": {
+				"browserify-cipher": "1.0.0",
+				"browserify-sign": "4.0.4",
+				"create-ecdh": "4.0.0",
+				"create-hash": "1.1.3",
+				"create-hmac": "1.1.6",
+				"diffie-hellman": "5.0.2",
+				"inherits": "2.0.3",
+				"pbkdf2": "3.0.14",
+				"public-encrypt": "4.0.0",
+				"randombytes": "2.0.6",
+				"randomfill": "1.0.3"
+			}
+		},
+		"css-color-function": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/css-color-function/-/css-color-function-1.3.3.tgz",
+			"integrity": "sha1-jtJMLAIFBzM5+voAS8jBQfzLKC4=",
+			"dev": true,
+			"requires": {
+				"balanced-match": "0.1.0",
+				"color": "0.11.4",
+				"debug": "3.1.0",
+				"rgb": "0.1.0"
+			},
+			"dependencies": {
+				"balanced-match": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
+					"integrity": "sha1-tQS9BYabOSWd0MXvw12EMXbczEo=",
+					"dev": true
+				}
+			}
+		},
+		"css-color-names": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+			"dev": true
+		},
+		"css-loader": {
+			"version": "0.28.7",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.7.tgz",
+			"integrity": "sha512-GxMpax8a/VgcfRrVy0gXD6yLd5ePYbXX/5zGgTVYp4wXtJklS8Z2VaUArJgc//f6/Dzil7BaJObdSv8eKKCPgg==",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"css-selector-tokenizer": "0.7.0",
+				"cssnano": "3.10.0",
+				"icss-utils": "2.1.0",
+				"loader-utils": "1.1.0",
+				"lodash.camelcase": "4.3.0",
+				"object-assign": "4.1.1",
+				"postcss": "5.2.18",
+				"postcss-modules-extract-imports": "1.1.0",
+				"postcss-modules-local-by-default": "1.2.0",
+				"postcss-modules-scope": "1.1.0",
+				"postcss-modules-values": "1.3.0",
+				"postcss-value-parser": "3.3.0",
+				"source-list-map": "2.0.0"
 			}
 		},
 		"css-modules-loader-core": {
@@ -209,6 +842,28 @@
 				"postcss-modules-local-by-default": "1.2.0",
 				"postcss-modules-scope": "1.1.0",
 				"postcss-modules-values": "1.3.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
+					"integrity": "sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=",
+					"dev": true,
+					"requires": {
+						"chalk": "1.1.3",
+						"source-map": "0.5.7",
+						"supports-color": "3.2.3"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
 			}
 		},
 		"css-selector-tokenizer": {
@@ -222,17 +877,205 @@
 				"regexpu-core": "1.0.0"
 			}
 		},
+		"css-unit-converter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
+			"integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
+			"dev": true
+		},
 		"cssesc": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
 			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
 			"dev": true
 		},
+		"cssnano": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+			"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+			"dev": true,
+			"requires": {
+				"autoprefixer": "6.7.7",
+				"decamelize": "1.2.0",
+				"defined": "1.0.0",
+				"has": "1.0.1",
+				"object-assign": "4.1.1",
+				"postcss": "5.2.18",
+				"postcss-calc": "5.3.1",
+				"postcss-colormin": "2.2.2",
+				"postcss-convert-values": "2.6.1",
+				"postcss-discard-comments": "2.0.4",
+				"postcss-discard-duplicates": "2.1.0",
+				"postcss-discard-empty": "2.1.0",
+				"postcss-discard-overridden": "0.1.1",
+				"postcss-discard-unused": "2.2.3",
+				"postcss-filter-plugins": "2.0.2",
+				"postcss-merge-idents": "2.1.7",
+				"postcss-merge-longhand": "2.0.2",
+				"postcss-merge-rules": "2.1.2",
+				"postcss-minify-font-values": "1.0.5",
+				"postcss-minify-gradients": "1.0.5",
+				"postcss-minify-params": "1.2.2",
+				"postcss-minify-selectors": "2.1.1",
+				"postcss-normalize-charset": "1.1.1",
+				"postcss-normalize-url": "3.0.8",
+				"postcss-ordered-values": "2.2.3",
+				"postcss-reduce-idents": "2.4.0",
+				"postcss-reduce-initial": "1.0.1",
+				"postcss-reduce-transforms": "1.0.4",
+				"postcss-svgo": "2.1.6",
+				"postcss-unique-selectors": "2.0.2",
+				"postcss-value-parser": "3.3.0",
+				"postcss-zindex": "2.2.0"
+			}
+		},
+		"csso": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+			"integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+			"dev": true,
+			"requires": {
+				"clap": "1.2.3",
+				"source-map": "0.5.7"
+			}
+		},
+		"cyclist": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+			"dev": true
+		},
+		"d": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+			"dev": true,
+			"requires": {
+				"es5-ext": "0.10.38"
+			}
+		},
+		"date-now": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+			"dev": true
+		},
+		"debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dev": true,
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
+		},
+		"defined": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+			"dev": true
+		},
+		"des.js": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0"
+			}
+		},
+		"diffie-hellman": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+			"dev": true,
+			"requires": {
+				"bn.js": "4.11.8",
+				"miller-rabin": "4.0.1",
+				"randombytes": "2.0.6"
+			}
+		},
+		"domain-browser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+			"dev": true
+		},
+		"duplexify": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
+			"integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.4",
+				"stream-shift": "1.0.0"
+			}
+		},
+		"electron-to-chromium": {
+			"version": "1.3.33",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz",
+			"integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU=",
+			"dev": true
+		},
+		"elliptic": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+			"dev": true,
+			"requires": {
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0",
+				"hash.js": "1.1.3",
+				"hmac-drbg": "1.0.1",
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0",
+				"minimalistic-crypto-utils": "1.0.1"
+			}
+		},
+		"emojis-list": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+			"dev": true
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"dev": true,
+			"requires": {
+				"once": "1.4.0"
+			}
+		},
+		"enhanced-resolve": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+			"integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"memory-fs": "0.4.1",
+				"object-assign": "4.1.1",
+				"tapable": "0.2.8"
+			}
+		},
+		"errno": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
+			"integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
+			"dev": true,
+			"requires": {
+				"prr": "1.0.1"
+			}
 		},
 		"error-ex": {
 			"version": "1.3.1",
@@ -241,6 +1084,90 @@
 			"dev": true,
 			"requires": {
 				"is-arrayish": "0.2.1"
+			},
+			"dependencies": {
+				"is-arrayish": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+					"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+					"dev": true
+				}
+			}
+		},
+		"es5-ext": {
+			"version": "0.10.38",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
+			"integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
+			"dev": true,
+			"requires": {
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.38",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"es6-map": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.38",
+				"es6-iterator": "2.0.3",
+				"es6-set": "0.1.5",
+				"es6-symbol": "3.1.1",
+				"event-emitter": "0.3.5"
+			}
+		},
+		"es6-object-assign": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+			"integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+			"dev": true
+		},
+		"es6-set": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.38",
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1",
+				"event-emitter": "0.3.5"
+			}
+		},
+		"es6-symbol": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.38"
+			}
+		},
+		"es6-weak-map": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.38",
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1"
 			}
 		},
 		"escape-string-regexp": {
@@ -248,6 +1175,72 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"dev": true
+		},
+		"escope": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+			"dev": true,
+			"requires": {
+				"es6-map": "0.1.5",
+				"es6-weak-map": "2.0.2",
+				"esrecurse": "4.2.0",
+				"estraverse": "4.2.0"
+			}
+		},
+		"esprima": {
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+			"dev": true
+		},
+		"esrecurse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+			"dev": true,
+			"requires": {
+				"estraverse": "4.2.0",
+				"object-assign": "4.1.1"
+			}
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
+		},
+		"event-emitter": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.38"
+			}
+		},
+		"events": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+			"dev": true
+		},
+		"evp_bytestokey": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+			"dev": true,
+			"requires": {
+				"md5.js": "1.3.4",
+				"safe-buffer": "5.1.1"
+			}
 		},
 		"execa": {
 			"version": "0.7.0",
@@ -291,11 +1284,45 @@
 				"is-extglob": "1.0.0"
 			}
 		},
+		"extract-text-webpack-plugin": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.2.tgz",
+			"integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
+			"dev": true,
+			"requires": {
+				"async": "2.6.0",
+				"loader-utils": "1.1.0",
+				"schema-utils": "0.3.0",
+				"webpack-sources": "1.1.0"
+			}
+		},
+		"fast-deep-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
+		},
 		"fastparse": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
 			"integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
 			"dev": true
+		},
+		"file-loader": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.5.tgz",
+			"integrity": "sha512-RzGHDatcVNpGISTvCpfUfOGpYuSR7HSsSg87ki+wF6rw1Hm0RALPTiAdsxAq1UwLf0RRhbe22/eHK6nhXspiOQ==",
+			"dev": true,
+			"requires": {
+				"loader-utils": "1.1.0",
+				"schema-utils": "0.3.0"
+			}
 		},
 		"filename-regex": {
 			"version": "2.0.1",
@@ -316,6 +1343,17 @@
 				"repeat-string": "1.6.1"
 			}
 		},
+		"find-cache-dir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+			"dev": true,
+			"requires": {
+				"commondir": "1.0.1",
+				"make-dir": "1.1.0",
+				"pkg-dir": "2.0.0"
+			}
+		},
 		"find-up": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -323,6 +1361,22 @@
 			"dev": true,
 			"requires": {
 				"locate-path": "2.0.0"
+			}
+		},
+		"flatten": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
+			"dev": true
+		},
+		"flush-write-stream": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+			"integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.4"
 			}
 		},
 		"for-in": {
@@ -338,6 +1392,28 @@
 			"dev": true,
 			"requires": {
 				"for-in": "1.0.2"
+			}
+		},
+		"from2": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.4"
+			}
+		},
+		"fs-write-stream-atomic": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"iferr": "0.1.5",
+				"imurmurhash": "0.1.4",
+				"readable-stream": "2.3.4"
 			}
 		},
 		"fs.realpath": {
@@ -359,13 +1435,15 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+					"integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
 					"dev": true,
 					"optional": true
 				},
 				"ajv": {
 					"version": "4.11.8",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+					"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -375,18 +1453,21 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true
 				},
 				"aproba": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+					"integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
 					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -396,42 +1477,49 @@
 				},
 				"asn1": {
 					"version": "0.2.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+					"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
 					"dev": true,
 					"optional": true
 				},
 				"assert-plus": {
 					"version": "0.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
 					"dev": true,
 					"optional": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 					"dev": true,
 					"optional": true
 				},
 				"aws-sign2": {
 					"version": "0.6.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
 					"dev": true,
 					"optional": true
 				},
 				"aws4": {
 					"version": "1.6.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+					"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
 					"dev": true,
 					"optional": true
 				},
 				"balanced-match": {
 					"version": "0.4.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
 					"dev": true
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+					"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -440,7 +1528,8 @@
 				},
 				"block-stream": {
 					"version": "0.0.9",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 					"dev": true,
 					"requires": {
 						"inherits": "2.0.3"
@@ -448,7 +1537,8 @@
 				},
 				"boom": {
 					"version": "2.10.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
 					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
@@ -456,7 +1546,8 @@
 				},
 				"brace-expansion": {
 					"version": "1.1.7",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+					"integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
 					"dev": true,
 					"requires": {
 						"balanced-match": "0.4.2",
@@ -465,29 +1556,34 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+					"integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
 					"dev": true
 				},
 				"caseless": {
 					"version": "0.12.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 					"dev": true,
 					"optional": true
 				},
 				"co": {
 					"version": "4.6.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"dev": true
 				},
 				"combined-stream": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
 					"dev": true,
 					"requires": {
 						"delayed-stream": "1.0.0"
@@ -495,22 +1591,26 @@
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 					"dev": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
 					"dev": true,
 					"requires": {
 						"boom": "2.10.1"
@@ -518,7 +1618,8 @@
 				},
 				"dashdash": {
 					"version": "1.14.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -527,7 +1628,8 @@
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 							"dev": true,
 							"optional": true
 						}
@@ -535,7 +1637,8 @@
 				},
 				"debug": {
 					"version": "2.6.8",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -544,30 +1647,35 @@
 				},
 				"deep-extend": {
 					"version": "0.4.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
 					"dev": true,
 					"optional": true
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 					"dev": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+					"integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
 					"dev": true,
 					"optional": true
 				},
 				"ecc-jsbn": {
 					"version": "0.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+					"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -576,24 +1684,28 @@
 				},
 				"extend": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+					"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
 					"dev": true,
 					"optional": true
 				},
 				"extsprintf": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+					"integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
 					"dev": true
 				},
 				"forever-agent": {
 					"version": "0.6.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
 					"dev": true,
 					"optional": true
 				},
 				"form-data": {
 					"version": "2.1.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -604,12 +1716,14 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"dev": true
 				},
 				"fstream": {
 					"version": "1.0.11",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
@@ -620,7 +1734,8 @@
 				},
 				"fstream-ignore": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+					"integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -631,7 +1746,8 @@
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -647,7 +1763,8 @@
 				},
 				"getpass": {
 					"version": "0.1.7",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -656,7 +1773,8 @@
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 							"dev": true,
 							"optional": true
 						}
@@ -664,7 +1782,8 @@
 				},
 				"glob": {
 					"version": "7.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"dev": true,
 					"requires": {
 						"fs.realpath": "1.0.0",
@@ -677,18 +1796,21 @@
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
 					"dev": true
 				},
 				"har-schema": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+					"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
 					"dev": true,
 					"optional": true
 				},
 				"har-validator": {
 					"version": "4.2.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+					"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -698,13 +1820,15 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"dev": true,
 					"optional": true
 				},
 				"hawk": {
 					"version": "3.1.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
 					"dev": true,
 					"requires": {
 						"boom": "2.10.1",
@@ -715,12 +1839,14 @@
 				},
 				"hoek": {
 					"version": "2.16.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
 					"dev": true
 				},
 				"http-signature": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -731,7 +1857,8 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"dev": true,
 					"requires": {
 						"once": "1.4.0",
@@ -740,18 +1867,21 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 					"dev": true
 				},
 				"ini": {
 					"version": "1.3.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+					"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
 					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
@@ -759,24 +1889,28 @@
 				},
 				"is-typedarray": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 					"dev": true,
 					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"dev": true
 				},
 				"isstream": {
 					"version": "0.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
 					"dev": true,
 					"optional": true
 				},
 				"jodid25519": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+					"integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -785,19 +1919,22 @@
 				},
 				"jsbn": {
 					"version": "0.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
 					"dev": true,
 					"optional": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
 					"dev": true,
 					"optional": true
 				},
 				"json-stable-stringify": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+					"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -806,19 +1943,22 @@
 				},
 				"json-stringify-safe": {
 					"version": "5.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 					"dev": true,
 					"optional": true
 				},
 				"jsonify": {
 					"version": "0.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+					"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
 					"dev": true,
 					"optional": true
 				},
 				"jsprim": {
 					"version": "1.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+					"integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -830,7 +1970,8 @@
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 							"dev": true,
 							"optional": true
 						}
@@ -838,12 +1979,14 @@
 				},
 				"mime-db": {
 					"version": "1.27.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+					"integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
 					"dev": true
 				},
 				"mime-types": {
 					"version": "2.1.15",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+					"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
 					"dev": true,
 					"requires": {
 						"mime-db": "1.27.0"
@@ -851,7 +1994,8 @@
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.7"
@@ -859,12 +2003,14 @@
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
@@ -872,13 +2018,15 @@
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true,
 					"optional": true
 				},
 				"node-pre-gyp": {
 					"version": "0.6.39",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+					"integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -897,7 +2045,8 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -907,7 +2056,8 @@
 				},
 				"npmlog": {
 					"version": "4.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+					"integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -919,24 +2069,28 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"dev": true
 				},
 				"oauth-sign": {
 					"version": "0.8.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
 					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
 					"requires": {
 						"wrappy": "1.0.2"
@@ -944,19 +2098,22 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+					"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -966,35 +2123,41 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"dev": true
 				},
 				"performance-now": {
 					"version": "0.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+					"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
 					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
 					"dev": true
 				},
 				"punycode": {
 					"version": "1.4.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 					"dev": true,
 					"optional": true
 				},
 				"qs": {
 					"version": "6.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+					"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
 					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+					"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -1006,7 +2169,8 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 							"dev": true,
 							"optional": true
 						}
@@ -1014,7 +2178,8 @@
 				},
 				"readable-stream": {
 					"version": "2.2.9",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+					"integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
 					"dev": true,
 					"requires": {
 						"buffer-shims": "1.0.0",
@@ -1028,7 +2193,8 @@
 				},
 				"request": {
 					"version": "2.81.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+					"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -1058,7 +2224,8 @@
 				},
 				"rimraf": {
 					"version": "2.6.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+					"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
 					"dev": true,
 					"requires": {
 						"glob": "7.1.2"
@@ -1066,30 +2233,35 @@
 				},
 				"safe-buffer": {
 					"version": "5.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+					"integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
 					"dev": true
 				},
 				"semver": {
 					"version": "5.3.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
 					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true,
 					"optional": true
 				},
 				"sntp": {
 					"version": "1.0.9",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
 					"dev": true,
 					"requires": {
 						"hoek": "2.16.3"
@@ -1097,7 +2269,8 @@
 				},
 				"sshpk": {
 					"version": "1.13.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+					"integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -1114,7 +2287,8 @@
 					"dependencies": {
 						"assert-plus": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+							"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 							"dev": true,
 							"optional": true
 						}
@@ -1122,7 +2296,8 @@
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
@@ -1132,7 +2307,8 @@
 				},
 				"string_decoder": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
 					"dev": true,
 					"requires": {
 						"safe-buffer": "5.0.1"
@@ -1140,13 +2316,15 @@
 				},
 				"stringstream": {
 					"version": "0.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+					"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
 					"dev": true,
 					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
@@ -1154,13 +2332,15 @@
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "2.2.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 					"dev": true,
 					"requires": {
 						"block-stream": "0.0.9",
@@ -1170,7 +2350,8 @@
 				},
 				"tar-pack": {
 					"version": "3.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+					"integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -1186,7 +2367,8 @@
 				},
 				"tough-cookie": {
 					"version": "2.3.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+					"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -1195,7 +2377,8 @@
 				},
 				"tunnel-agent": {
 					"version": "0.6.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -1204,30 +2387,35 @@
 				},
 				"tweetnacl": {
 					"version": "0.14.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
 					"dev": true,
 					"optional": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+					"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
 					"dev": true,
 					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 					"dev": true
 				},
 				"uuid": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+					"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
 					"dev": true,
 					"optional": true
 				},
 				"verror": {
 					"version": "1.3.6",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+					"integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -1236,7 +2424,8 @@
 				},
 				"wide-align": {
 					"version": "1.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -1245,10 +2434,17 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 					"dev": true
 				}
 			}
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"get-caller-file": {
 			"version": "1.0.2",
@@ -1301,6 +2497,15 @@
 			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
 			"dev": true
 		},
+		"has": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"dev": true,
+			"requires": {
+				"function-bind": "1.1.1"
+			}
+		},
 		"has-ansi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -1311,10 +2516,40 @@
 			}
 		},
 		"has-flag": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
 			"dev": true
+		},
+		"hash-base": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3"
+			}
+		},
+		"hash.js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.0"
+			}
+		},
+		"hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"dev": true,
+			"requires": {
+				"hash.js": "1.1.3",
+				"minimalistic-assert": "1.0.0",
+				"minimalistic-crypto-utils": "1.0.1"
+			}
 		},
 		"hosted-git-info": {
 			"version": "2.5.0",
@@ -1322,10 +2557,125 @@
 			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
 			"dev": true
 		},
+		"html-comment-regex": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
+			"integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
+			"dev": true
+		},
+		"https-browserify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+			"dev": true
+		},
 		"icss-replace-symbols": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
 			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+			"dev": true
+		},
+		"icss-utils": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
+			"integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+			"dev": true,
+			"requires": {
+				"postcss": "6.0.17"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"ieee754": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+			"dev": true
+		},
+		"iferr": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+			"dev": true
+		},
+		"imports-loader": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.7.1.tgz",
+			"integrity": "sha1-8gS180cCoywdt9SNidXoZ6BEElM=",
+			"dev": true,
+			"requires": {
+				"loader-utils": "1.1.0",
+				"source-map": "0.5.7"
+			}
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"indexes-of": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+			"dev": true
+		},
+		"indexof": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
 			"dev": true
 		},
 		"inflight": {
@@ -1344,16 +2694,34 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 			"dev": true
 		},
+		"interpret": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+			"dev": true
+		},
+		"intersection-observer": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.4.3.tgz",
+			"integrity": "sha512-sRobbVo/+DVGkbco/UkuREmXSr5ypWeQ7S7tYDhzIIP3NFtAHLkkFYdivFAIgNe4sfDYBFAjxEgUyxiEmA/dgQ==",
+			"dev": true
+		},
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
 			"dev": true
 		},
+		"is-absolute-url": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+			"integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
+			"dev": true
+		},
 		"is-arrayish": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.1.tgz",
+			"integrity": "sha1-wt/DhquqDD4zxI2z/ocFnmkGXv0=",
 			"dev": true
 		},
 		"is-binary-path": {
@@ -1379,6 +2747,12 @@
 			"requires": {
 				"builtin-modules": "1.1.1"
 			}
+		},
+		"is-directory": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+			"dev": true
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
@@ -1434,6 +2808,12 @@
 				"kind-of": "3.2.2"
 			}
 		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+			"dev": true
+		},
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
@@ -1451,6 +2831,15 @@
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
 			"dev": true
+		},
+		"is-svg": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+			"integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+			"dev": true,
+			"requires": {
+				"html-comment-regex": "1.1.1"
+			}
 		},
 		"is-there": {
 			"version": "4.4.3",
@@ -1470,6 +2859,12 @@
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
 		},
+		"isnumeric": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/isnumeric/-/isnumeric-0.2.0.tgz",
+			"integrity": "sha1-ojR7o2DeGeM9D/1ZD933dVy/LmQ=",
+			"dev": true
+		},
 		"isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
@@ -1479,10 +2874,56 @@
 				"isarray": "1.0.0"
 			}
 		},
+		"js-base64": {
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
+			"integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
+			"dev": true
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+			"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+			"dev": true,
+			"requires": {
+				"argparse": "1.0.9",
+				"esprima": "2.7.3"
+			}
+		},
 		"jsesc": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
 			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+			"dev": true
+		},
+		"json-css-module-loader": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-css-module-loader/-/json-css-module-loader-1.0.2.tgz",
+			"integrity": "sha512-toY6hod2C4ehC/R3jQqiUfpgBuuLcgw5KLoQhFaH93NSJ9w83RujL8tfc6gdJQR8fej5NF8UfWSBFwuEDvOBhw==",
+			"dev": true
+		},
+		"json-loader": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+			"integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+			"dev": true
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
+		},
+		"json5": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
 			"dev": true
 		},
 		"kind-of": {
@@ -1493,6 +2934,12 @@
 			"requires": {
 				"is-buffer": "1.1.6"
 			}
+		},
+		"lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"dev": true
 		},
 		"lcid": {
 			"version": "1.0.0",
@@ -1515,6 +2962,23 @@
 				"strip-bom": "3.0.0"
 			}
 		},
+		"loader-runner": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
+			"integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
+			"dev": true
+		},
+		"loader-utils": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+			"dev": true,
+			"requires": {
+				"big.js": "3.2.0",
+				"emojis-list": "2.1.0",
+				"json5": "0.5.1"
+			}
+		},
 		"locate-path": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -1524,6 +2988,61 @@
 				"p-locate": "2.0.0",
 				"path-exists": "3.0.0"
 			}
+		},
+		"lodash": {
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+			"dev": true
+		},
+		"lodash._reinterpolate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+			"dev": true
+		},
+		"lodash.camelcase": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+			"dev": true
+		},
+		"lodash.memoize": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+			"dev": true
+		},
+		"lodash.template": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+			"dev": true,
+			"requires": {
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.templatesettings": "4.1.0"
+			}
+		},
+		"lodash.templatesettings": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+			"dev": true,
+			"requires": {
+				"lodash._reinterpolate": "3.0.0"
+			}
+		},
+		"lodash.uniq": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+			"dev": true
+		},
+		"longest": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+			"dev": true
 		},
 		"lru-cache": {
 			"version": "4.1.1",
@@ -1535,13 +3054,74 @@
 				"yallist": "2.1.2"
 			}
 		},
+		"macaddress": {
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
+			"integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
+			"dev": true
+		},
+		"make-dir": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
+			"integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+			"dev": true,
+			"requires": {
+				"pify": "3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
+			}
+		},
+		"math-expression-evaluator": {
+			"version": "1.2.17",
+			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+			"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
+			"dev": true
+		},
+		"md5.js": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+			"dev": true,
+			"requires": {
+				"hash-base": "3.0.4",
+				"inherits": "2.0.3"
+			},
+			"dependencies": {
+				"hash-base": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+					"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+					"dev": true,
+					"requires": {
+						"inherits": "2.0.3",
+						"safe-buffer": "5.1.1"
+					}
+				}
+			}
+		},
 		"mem": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "1.1.0"
+				"mimic-fn": "1.2.0"
+			}
+		},
+		"memory-fs": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+			"dev": true,
+			"requires": {
+				"errno": "0.1.6",
+				"readable-stream": "2.3.4"
 			}
 		},
 		"micromatch": {
@@ -1565,10 +3145,32 @@
 				"regex-cache": "0.4.4"
 			}
 		},
+		"miller-rabin": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+			"dev": true,
+			"requires": {
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0"
+			}
+		},
 		"mimic-fn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-			"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
+		},
+		"minimalistic-assert": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+			"integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
+			"dev": true
+		},
+		"minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
 			"dev": true
 		},
 		"minimatch": {
@@ -1577,7 +3179,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.8"
+				"brace-expansion": "1.1.11"
 			}
 		},
 		"minimist": {
@@ -1585,6 +3187,24 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 			"dev": true
+		},
+		"mississippi": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.1.tgz",
+			"integrity": "sha512-/6rB8YXFbAtsUVRphIRQqB0+9c7VaPHCjVtvto+JqwVxgz8Zz+I+f68/JgQ+Pb4VlZb2svA9OtdXnHHsZz7ltg==",
+			"dev": true,
+			"requires": {
+				"concat-stream": "1.6.0",
+				"duplexify": "3.5.3",
+				"end-of-stream": "1.4.1",
+				"flush-write-stream": "1.0.2",
+				"from2": "2.3.0",
+				"parallel-transform": "1.1.0",
+				"pump": "1.0.3",
+				"pumpify": "1.4.0",
+				"stream-each": "1.2.2",
+				"through2": "2.0.3"
+			}
 		},
 		"mkdirp": {
 			"version": "0.5.1",
@@ -1595,12 +3215,63 @@
 				"minimist": "0.0.8"
 			}
 		},
+		"move-concurrently": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+			"dev": true,
+			"requires": {
+				"aproba": "1.2.0",
+				"copy-concurrently": "1.0.5",
+				"fs-write-stream-atomic": "1.0.10",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"run-queue": "1.0.3"
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
 		"nan": {
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
 			"integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
 			"dev": true,
 			"optional": true
+		},
+		"node-libs-browser": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+			"dev": true,
+			"requires": {
+				"assert": "1.4.1",
+				"browserify-zlib": "0.2.0",
+				"buffer": "4.9.1",
+				"console-browserify": "1.1.0",
+				"constants-browserify": "1.0.0",
+				"crypto-browserify": "3.12.0",
+				"domain-browser": "1.2.0",
+				"events": "1.1.1",
+				"https-browserify": "1.0.0",
+				"os-browserify": "0.3.0",
+				"path-browserify": "0.0.0",
+				"process": "0.11.10",
+				"punycode": "1.4.1",
+				"querystring-es3": "0.2.1",
+				"readable-stream": "2.3.4",
+				"stream-browserify": "2.0.1",
+				"stream-http": "2.8.0",
+				"string_decoder": "1.0.3",
+				"timers-browserify": "2.0.6",
+				"tty-browserify": "0.0.0",
+				"url": "0.11.0",
+				"util": "0.10.3",
+				"vm-browserify": "0.0.4"
+			}
 		},
 		"normalize-package-data": {
 			"version": "2.4.0",
@@ -1623,6 +3294,24 @@
 				"remove-trailing-separator": "1.1.0"
 			}
 		},
+		"normalize-range": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+			"dev": true
+		},
+		"normalize-url": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+			"dev": true,
+			"requires": {
+				"object-assign": "4.1.1",
+				"prepend-http": "1.0.4",
+				"query-string": "4.3.4",
+				"sort-keys": "1.1.2"
+			}
+		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -1632,10 +3321,22 @@
 				"path-key": "2.0.1"
 			}
 		},
+		"num2fraction": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+			"dev": true
+		},
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 			"dev": true
 		},
 		"object.omit": {
@@ -1656,6 +3357,24 @@
 			"requires": {
 				"wrappy": "1.0.2"
 			}
+		},
+		"onecolor": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/onecolor/-/onecolor-3.0.5.tgz",
+			"integrity": "sha1-Nu/zIgE3nv3xGA+0ReUajiQl+fY=",
+			"dev": true
+		},
+		"os-browserify": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+			"dev": true
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-locale": {
 			"version": "2.1.0",
@@ -1698,6 +3417,36 @@
 			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 			"dev": true
 		},
+		"pako": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+			"dev": true
+		},
+		"parallel-transform": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+			"dev": true,
+			"requires": {
+				"cyclist": "0.2.2",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.4"
+			}
+		},
+		"parse-asn1": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+			"dev": true,
+			"requires": {
+				"asn1.js": "4.9.2",
+				"browserify-aes": "1.1.1",
+				"create-hash": "1.1.3",
+				"evp_bytestokey": "1.0.3",
+				"pbkdf2": "3.0.14"
+			}
+		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -1719,6 +3468,12 @@
 				"error-ex": "1.3.1"
 			}
 		},
+		"path-browserify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+			"dev": true
+		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -1737,6 +3492,12 @@
 			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
 			"dev": true
 		},
+		"path-parse": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+			"dev": true
+		},
 		"path-type": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
@@ -1746,56 +3507,191 @@
 				"pify": "2.3.0"
 			}
 		},
+		"pbkdf2": {
+			"version": "3.0.14",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
+			"integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+			"dev": true,
+			"requires": {
+				"create-hash": "1.1.3",
+				"create-hmac": "1.1.6",
+				"ripemd160": "2.0.1",
+				"safe-buffer": "5.1.1",
+				"sha.js": "2.4.10"
+			}
+		},
+		"pepjs": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/pepjs/-/pepjs-0.4.3.tgz",
+			"integrity": "sha1-FggOlwqud5kTdWwtrviOqnSG30E=",
+			"dev": true
+		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 			"dev": true
 		},
+		"pixrem": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pixrem/-/pixrem-4.0.1.tgz",
+			"integrity": "sha1-LaSh3m7EQjxfw3lOkwuB1EkOxoY=",
+			"dev": true,
+			"requires": {
+				"browserslist": "2.11.3",
+				"postcss": "6.0.17",
+				"reduce-css-calc": "1.3.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"browserslist": {
+					"version": "2.11.3",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+					"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "1.0.30000808",
+						"electron-to-chromium": "1.3.33"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"pkg-dir": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"dev": true,
+			"requires": {
+				"find-up": "2.1.0"
+			}
+		},
+		"pleeease-filters": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/pleeease-filters/-/pleeease-filters-4.0.0.tgz",
+			"integrity": "sha1-ZjKy+wVkjSdY2GU4T7zteeHMrsc=",
+			"dev": true,
+			"requires": {
+				"onecolor": "3.0.5",
+				"postcss": "6.0.17"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
 		"postcss": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
-			"integrity": "sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=",
+			"version": "5.2.18",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+			"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
 			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
+				"js-base64": "2.4.3",
 				"source-map": "0.5.7",
 				"supports-color": "3.2.3"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-							"dev": true
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
-				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
@@ -1807,13 +3703,1746 @@
 				}
 			}
 		},
+		"postcss-apply": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/postcss-apply/-/postcss-apply-0.8.0.tgz",
+			"integrity": "sha1-FOVEu7XLbxweBIhXll15rgZrE0M=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"balanced-match": "0.4.2",
+				"postcss": "6.0.17"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-attribute-case-insensitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-2.0.0.tgz",
+			"integrity": "sha1-lNxCLI+QmX8WvTOjZUu77AhJY7Q=",
+			"dev": true,
+			"requires": {
+				"postcss": "6.0.17",
+				"postcss-selector-parser": "2.2.3"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-calc": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+			"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
+			"dev": true,
+			"requires": {
+				"postcss": "5.2.18",
+				"postcss-message-helpers": "2.0.0",
+				"reduce-css-calc": "1.3.0"
+			}
+		},
+		"postcss-color-function": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-color-function/-/postcss-color-function-4.0.1.tgz",
+			"integrity": "sha1-QCs/LOvD9pR+YY+2vjZU++zvZEQ=",
+			"dev": true,
+			"requires": {
+				"css-color-function": "1.3.3",
+				"postcss": "6.0.17",
+				"postcss-message-helpers": "2.0.0",
+				"postcss-value-parser": "3.3.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-color-gray": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-4.1.0.tgz",
+			"integrity": "sha512-L4iLKQLdqChz6ZOgGb6dRxkBNw78JFYcJmBz1orHpZoeLtuhDDGegRtX9gSyfoCIM7rWZ3VNOyiqqvk83BEN+w==",
+			"dev": true,
+			"requires": {
+				"color": "2.0.1",
+				"postcss": "6.0.17",
+				"postcss-message-helpers": "2.0.0",
+				"reduce-function-call": "1.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"color": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
+					"integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1",
+						"color-string": "1.5.2"
+					}
+				},
+				"color-string": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
+					"integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3",
+						"simple-swizzle": "0.2.2"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-color-hex-alpha": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-3.0.0.tgz",
+			"integrity": "sha1-HlPmyKyyN5Vej9CLfs2xuLgwn5U=",
+			"dev": true,
+			"requires": {
+				"color": "1.0.3",
+				"postcss": "6.0.17",
+				"postcss-message-helpers": "2.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"color": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/color/-/color-1.0.3.tgz",
+					"integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1",
+						"color-string": "1.5.2"
+					}
+				},
+				"color-string": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
+					"integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3",
+						"simple-swizzle": "0.2.2"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-color-hsl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-color-hsl/-/postcss-color-hsl-2.0.0.tgz",
+			"integrity": "sha1-EnA2ZvoxBDDj8wpFTawThjF9WEQ=",
+			"dev": true,
+			"requires": {
+				"postcss": "6.0.17",
+				"postcss-value-parser": "3.3.0",
+				"units-css": "0.4.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-color-hwb": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-color-hwb/-/postcss-color-hwb-3.0.0.tgz",
+			"integrity": "sha1-NAKxnvTYSXVAwftQcr6YY8qVVx4=",
+			"dev": true,
+			"requires": {
+				"color": "1.0.3",
+				"postcss": "6.0.17",
+				"postcss-message-helpers": "2.0.0",
+				"reduce-function-call": "1.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"color": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/color/-/color-1.0.3.tgz",
+					"integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1",
+						"color-string": "1.5.2"
+					}
+				},
+				"color-string": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
+					"integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3",
+						"simple-swizzle": "0.2.2"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-color-rebeccapurple": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-3.0.0.tgz",
+			"integrity": "sha1-7rrwPTY7QwC5Z5K9MIHBntZlE9M=",
+			"dev": true,
+			"requires": {
+				"postcss": "6.0.17",
+				"postcss-value-parser": "3.3.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-color-rgb": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-color-rgb/-/postcss-color-rgb-2.0.0.tgz",
+			"integrity": "sha1-FFOcinExSUtILg3RzCZf9lFLUmM=",
+			"dev": true,
+			"requires": {
+				"postcss": "6.0.17",
+				"postcss-value-parser": "3.3.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-color-rgba-fallback": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-color-rgba-fallback/-/postcss-color-rgba-fallback-3.0.0.tgz",
+			"integrity": "sha1-N9XJNToHoJJwkSqCYGu0Kg1wLAQ=",
+			"dev": true,
+			"requires": {
+				"postcss": "6.0.17",
+				"postcss-value-parser": "3.3.0",
+				"rgb-hex": "2.1.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-colormin": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+			"integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
+			"dev": true,
+			"requires": {
+				"colormin": "1.1.2",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-convert-values": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+			"integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
+			"dev": true,
+			"requires": {
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-cssnext": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-cssnext/-/postcss-cssnext-3.0.2.tgz",
+			"integrity": "sha512-jA6kGdcUMZqLUgw6MdpyNWGFhk0LIITVhC/jTnLRZLoXSTR88qT2cFOn3LbY06udt1PVdTCHDG3plBjxVKf8BQ==",
+			"dev": true,
+			"requires": {
+				"autoprefixer": "7.2.6",
+				"caniuse-api": "2.0.0",
+				"chalk": "2.3.1",
+				"pixrem": "4.0.1",
+				"pleeease-filters": "4.0.0",
+				"postcss": "6.0.17",
+				"postcss-apply": "0.8.0",
+				"postcss-attribute-case-insensitive": "2.0.0",
+				"postcss-calc": "6.0.1",
+				"postcss-color-function": "4.0.1",
+				"postcss-color-gray": "4.1.0",
+				"postcss-color-hex-alpha": "3.0.0",
+				"postcss-color-hsl": "2.0.0",
+				"postcss-color-hwb": "3.0.0",
+				"postcss-color-rebeccapurple": "3.0.0",
+				"postcss-color-rgb": "2.0.0",
+				"postcss-color-rgba-fallback": "3.0.0",
+				"postcss-custom-media": "6.0.0",
+				"postcss-custom-properties": "6.2.0",
+				"postcss-custom-selectors": "4.0.1",
+				"postcss-font-family-system-ui": "2.1.4",
+				"postcss-font-variant": "3.0.0",
+				"postcss-image-set-polyfill": "0.3.5",
+				"postcss-initial": "2.0.0",
+				"postcss-media-minmax": "3.0.0",
+				"postcss-nesting": "4.2.1",
+				"postcss-pseudo-class-any-link": "4.0.0",
+				"postcss-pseudoelements": "5.0.0",
+				"postcss-replace-overflow-wrap": "2.0.0",
+				"postcss-selector-matches": "3.0.1",
+				"postcss-selector-not": "3.0.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"autoprefixer": {
+					"version": "7.2.6",
+					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
+					"integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
+					"dev": true,
+					"requires": {
+						"browserslist": "2.11.3",
+						"caniuse-lite": "1.0.30000808",
+						"normalize-range": "0.1.2",
+						"num2fraction": "1.2.2",
+						"postcss": "6.0.17",
+						"postcss-value-parser": "3.3.0"
+					}
+				},
+				"browserslist": {
+					"version": "2.11.3",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+					"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "1.0.30000808",
+						"electron-to-chromium": "1.3.33"
+					}
+				},
+				"caniuse-api": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-2.0.0.tgz",
+					"integrity": "sha1-sd21pZZrFvSNxJmERNS7xsfZ2DQ=",
+					"dev": true,
+					"requires": {
+						"browserslist": "2.11.3",
+						"caniuse-lite": "1.0.30000808",
+						"lodash.memoize": "4.1.2",
+						"lodash.uniq": "4.5.0"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"postcss-calc": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-6.0.1.tgz",
+					"integrity": "sha1-PSQXG79udinUIqQ26/5t2VEfQzA=",
+					"dev": true,
+					"requires": {
+						"css-unit-converter": "1.1.1",
+						"postcss": "6.0.17",
+						"postcss-selector-parser": "2.2.3",
+						"reduce-css-calc": "2.1.4"
+					}
+				},
+				"reduce-css-calc": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.4.tgz",
+					"integrity": "sha512-i/vWQbyd3aJRmip9OVSN9V6nIjLf/gg/ctxb0CpvHWtcRysFl/ngDBQD+rqavxdw/doScA3GMBXhzkHQ4GCzFQ==",
+					"dev": true,
+					"requires": {
+						"css-unit-converter": "1.1.1",
+						"postcss-value-parser": "3.3.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-custom-media": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-6.0.0.tgz",
+			"integrity": "sha1-vlMnhBEOyylQRPtTlaGABushpzc=",
+			"dev": true,
+			"requires": {
+				"postcss": "6.0.17"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-custom-properties": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-6.2.0.tgz",
+			"integrity": "sha512-eNR2h9T9ciKMoQEORrPjH33XeN/nuvVuxArOKmHtsFbGbNss631tgTrKou3/pmjAZbA4QQkhLIkPQkIk3WW+8w==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "1.0.0",
+				"postcss": "6.0.17"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-custom-selectors": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-4.0.1.tgz",
+			"integrity": "sha1-eBOC+UxS5yfvXKR3bqKt9JphE4I=",
+			"dev": true,
+			"requires": {
+				"postcss": "6.0.17",
+				"postcss-selector-matches": "3.0.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-discard-comments": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+			"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
+			"dev": true,
+			"requires": {
+				"postcss": "5.2.18"
+			}
+		},
+		"postcss-discard-duplicates": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+			"integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
+			"dev": true,
+			"requires": {
+				"postcss": "5.2.18"
+			}
+		},
+		"postcss-discard-empty": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+			"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
+			"dev": true,
+			"requires": {
+				"postcss": "5.2.18"
+			}
+		},
+		"postcss-discard-overridden": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+			"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
+			"dev": true,
+			"requires": {
+				"postcss": "5.2.18"
+			}
+		},
+		"postcss-discard-unused": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+			"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
+			"dev": true,
+			"requires": {
+				"postcss": "5.2.18",
+				"uniqs": "2.0.0"
+			}
+		},
+		"postcss-filter-plugins": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+			"integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+			"dev": true,
+			"requires": {
+				"postcss": "5.2.18",
+				"uniqid": "4.1.1"
+			}
+		},
+		"postcss-font-family-system-ui": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/postcss-font-family-system-ui/-/postcss-font-family-system-ui-2.1.4.tgz",
+			"integrity": "sha512-TkrNpYF0wjn4AsOH5CZADN9ijwRZc/ogHpiGrNR/dHvaJPJS0nNIeVTxFXFkkB4lG+DRWiYbMsP+G/vPuOyLkA==",
+			"dev": true,
+			"requires": {
+				"@std/esm": "0.19.7",
+				"postcss": "6.0.17",
+				"postcss-value-parser": "3.3.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-font-variant": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-3.0.0.tgz",
+			"integrity": "sha1-CMzIj2BQuoLtjvLMdsDGprQfGD4=",
+			"dev": true,
+			"requires": {
+				"postcss": "6.0.17"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-image-set-polyfill": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/postcss-image-set-polyfill/-/postcss-image-set-polyfill-0.3.5.tgz",
+			"integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
+			"dev": true,
+			"requires": {
+				"postcss": "6.0.17",
+				"postcss-media-query-parser": "0.2.3"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-import": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-11.0.0.tgz",
+			"integrity": "sha1-qWLi34LTvFptpqOGhBdHIE9B71s=",
+			"dev": true,
+			"requires": {
+				"postcss": "6.0.17",
+				"postcss-value-parser": "3.3.0",
+				"read-cache": "1.0.0",
+				"resolve": "1.5.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-initial": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-2.0.0.tgz",
+			"integrity": "sha1-cnFfczbgu3k1HZnuZcSiU6hEG6Q=",
+			"dev": true,
+			"requires": {
+				"lodash.template": "4.4.0",
+				"postcss": "6.0.17"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-load-config": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
+			"integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
+			"dev": true,
+			"requires": {
+				"cosmiconfig": "2.2.2",
+				"object-assign": "4.1.1",
+				"postcss-load-options": "1.2.0",
+				"postcss-load-plugins": "2.3.0"
+			}
+		},
+		"postcss-load-options": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
+			"integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
+			"dev": true,
+			"requires": {
+				"cosmiconfig": "2.2.2",
+				"object-assign": "4.1.1"
+			}
+		},
+		"postcss-load-plugins": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
+			"integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
+			"dev": true,
+			"requires": {
+				"cosmiconfig": "2.2.2",
+				"object-assign": "4.1.1"
+			}
+		},
+		"postcss-loader": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-1.0.0.tgz",
+			"integrity": "sha1-47ZdDIWWwWWPedfbLSkTEHSNXSo=",
+			"dev": true,
+			"requires": {
+				"loader-utils": "0.2.17",
+				"object-assign": "4.1.1",
+				"postcss": "5.2.18",
+				"postcss-load-config": "1.2.0"
+			},
+			"dependencies": {
+				"loader-utils": {
+					"version": "0.2.17",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+					"dev": true,
+					"requires": {
+						"big.js": "3.2.0",
+						"emojis-list": "2.1.0",
+						"json5": "0.5.1",
+						"object-assign": "4.1.1"
+					}
+				}
+			}
+		},
+		"postcss-media-minmax": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-3.0.0.tgz",
+			"integrity": "sha1-Z1JWA3pD70C8Twdgv9BtTcadSNI=",
+			"dev": true,
+			"requires": {
+				"postcss": "6.0.17"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-media-query-parser": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+			"integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
+			"dev": true
+		},
+		"postcss-merge-idents": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+			"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
+			"dev": true,
+			"requires": {
+				"has": "1.0.1",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-merge-longhand": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+			"integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
+			"dev": true,
+			"requires": {
+				"postcss": "5.2.18"
+			}
+		},
+		"postcss-merge-rules": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+			"integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
+			"dev": true,
+			"requires": {
+				"browserslist": "1.7.7",
+				"caniuse-api": "1.6.1",
+				"postcss": "5.2.18",
+				"postcss-selector-parser": "2.2.3",
+				"vendors": "1.0.1"
+			}
+		},
+		"postcss-message-helpers": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+			"integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
+			"dev": true
+		},
+		"postcss-minify-font-values": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+			"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
+			"dev": true,
+			"requires": {
+				"object-assign": "4.1.1",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-minify-gradients": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+			"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
+			"dev": true,
+			"requires": {
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-minify-params": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+			"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
+			"dev": true,
+			"requires": {
+				"alphanum-sort": "1.0.2",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0",
+				"uniqs": "2.0.0"
+			}
+		},
+		"postcss-minify-selectors": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+			"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
+			"dev": true,
+			"requires": {
+				"alphanum-sort": "1.0.2",
+				"has": "1.0.1",
+				"postcss": "5.2.18",
+				"postcss-selector-parser": "2.2.3"
+			}
+		},
 		"postcss-modules-extract-imports": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
 			"integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
 			"dev": true,
 			"requires": {
-				"postcss": "6.0.1"
+				"postcss": "6.0.17"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
 			}
 		},
 		"postcss-modules-local-by-default": {
@@ -1823,7 +5452,61 @@
 			"dev": true,
 			"requires": {
 				"css-selector-tokenizer": "0.7.0",
-				"postcss": "6.0.1"
+				"postcss": "6.0.17"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
 			}
 		},
 		"postcss-modules-scope": {
@@ -1833,7 +5516,61 @@
 			"dev": true,
 			"requires": {
 				"css-selector-tokenizer": "0.7.0",
-				"postcss": "6.0.1"
+				"postcss": "6.0.17"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
 			}
 		},
 		"postcss-modules-values": {
@@ -1843,8 +5580,561 @@
 			"dev": true,
 			"requires": {
 				"icss-replace-symbols": "1.1.0",
-				"postcss": "6.0.1"
+				"postcss": "6.0.17"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
 			}
+		},
+		"postcss-nesting": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-4.2.1.tgz",
+			"integrity": "sha512-IkyWXICwagCnlaviRexi7qOdwPw3+xVVjgFfGsxmztvRVaNxAlrypOIKqDE5mxY+BVxnId1rnUKBRQoNE2VDaA==",
+			"dev": true,
+			"requires": {
+				"postcss": "6.0.17"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-normalize-charset": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+			"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+			"dev": true,
+			"requires": {
+				"postcss": "5.2.18"
+			}
+		},
+		"postcss-normalize-url": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+			"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+			"dev": true,
+			"requires": {
+				"is-absolute-url": "2.1.0",
+				"normalize-url": "1.9.1",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-ordered-values": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+			"integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+			"dev": true,
+			"requires": {
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-pseudo-class-any-link": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-4.0.0.tgz",
+			"integrity": "sha1-kVKgYT00UHIFE+iJKFS65C0O5o4=",
+			"dev": true,
+			"requires": {
+				"postcss": "6.0.17",
+				"postcss-selector-parser": "2.2.3"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-pseudoelements": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-pseudoelements/-/postcss-pseudoelements-5.0.0.tgz",
+			"integrity": "sha1-7vGU6NUkZFylIKlJ6V5RjoEkAss=",
+			"dev": true,
+			"requires": {
+				"postcss": "6.0.17"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-reduce-idents": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+			"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
+			"dev": true,
+			"requires": {
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-reduce-initial": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+			"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+			"dev": true,
+			"requires": {
+				"postcss": "5.2.18"
+			}
+		},
+		"postcss-reduce-transforms": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+			"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+			"dev": true,
+			"requires": {
+				"has": "1.0.1",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0"
+			}
+		},
+		"postcss-replace-overflow-wrap": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-2.0.0.tgz",
+			"integrity": "sha1-eU22+qVPjbEAhUOSqTr0V2i04ls=",
+			"dev": true,
+			"requires": {
+				"postcss": "6.0.17"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-selector-matches": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-3.0.1.tgz",
+			"integrity": "sha1-5WNAEeE5UIgYYbvdWMLQER/8lqs=",
+			"dev": true,
+			"requires": {
+				"balanced-match": "0.4.2",
+				"postcss": "6.0.17"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-selector-not": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-3.0.1.tgz",
+			"integrity": "sha1-Lk2y8JZTNsAefOx9tsYN/3ZzNdk=",
+			"dev": true,
+			"requires": {
+				"balanced-match": "0.4.2",
+				"postcss": "6.0.17"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.17",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+					"integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+					"dev": true,
+					"requires": {
+						"chalk": "2.3.1",
+						"source-map": "0.6.1",
+						"supports-color": "5.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"postcss-selector-parser": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+			"dev": true,
+			"requires": {
+				"flatten": "1.0.2",
+				"indexes-of": "1.0.1",
+				"uniq": "1.0.1"
+			}
+		},
+		"postcss-svgo": {
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+			"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+			"dev": true,
+			"requires": {
+				"is-svg": "2.1.0",
+				"postcss": "5.2.18",
+				"postcss-value-parser": "3.3.0",
+				"svgo": "0.7.2"
+			}
+		},
+		"postcss-unique-selectors": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+			"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+			"dev": true,
+			"requires": {
+				"alphanum-sort": "1.0.2",
+				"postcss": "5.2.18",
+				"uniqs": "2.0.0"
+			}
+		},
+		"postcss-value-parser": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
+			"dev": true
+		},
+		"postcss-zindex": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+			"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
+			"dev": true,
+			"requires": {
+				"has": "1.0.1",
+				"postcss": "5.2.18",
+				"uniqs": "2.0.0"
+			}
+		},
+		"prepend-http": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+			"dev": true
 		},
 		"preserve": {
 			"version": "0.2.0",
@@ -1852,16 +6142,120 @@
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
 			"dev": true
 		},
+		"private": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"dev": true
+		},
+		"process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+			"dev": true
+		},
 		"process-nextick-args": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
+		},
+		"promise-inflight": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+			"dev": true
+		},
+		"prr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
 			"dev": true
 		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
+		},
+		"public-encrypt": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+			"dev": true,
+			"requires": {
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.1.3",
+				"parse-asn1": "5.1.0",
+				"randombytes": "2.0.6"
+			}
+		},
+		"pump": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+			"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"once": "1.4.0"
+			}
+		},
+		"pumpify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
+			"integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+			"dev": true,
+			"requires": {
+				"duplexify": "3.5.3",
+				"inherits": "2.0.3",
+				"pump": "2.0.1"
+			},
+			"dependencies": {
+				"pump": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+					"dev": true,
+					"requires": {
+						"end-of-stream": "1.4.1",
+						"once": "1.4.0"
+					}
+				}
+			}
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
+		},
+		"q": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+			"dev": true
+		},
+		"query-string": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+			"dev": true,
+			"requires": {
+				"object-assign": "4.1.1",
+				"strict-uri-encode": "1.1.0"
+			}
+		},
+		"querystring": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+			"dev": true
+		},
+		"querystring-es3": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
 			"dev": true
 		},
 		"randomatic": {
@@ -1905,6 +6299,34 @@
 				}
 			}
 		},
+		"randombytes": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"randomfill": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
+			"integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+			"dev": true,
+			"requires": {
+				"randombytes": "2.0.6",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"read-cache": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+			"integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
+			"dev": true,
+			"requires": {
+				"pify": "2.3.0"
+			}
+		},
 		"read-pkg": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -1927,15 +6349,15 @@
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+			"integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
 			"dev": true,
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
 				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
+				"process-nextick-args": "2.0.0",
 				"safe-buffer": "5.1.1",
 				"string_decoder": "1.0.3",
 				"util-deprecate": "1.0.2"
@@ -1949,14 +6371,76 @@
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"minimatch": "3.0.4",
-				"readable-stream": "2.3.3",
+				"readable-stream": "2.3.4",
 				"set-immediate-shim": "1.0.1"
+			}
+		},
+		"recast": {
+			"version": "0.12.9",
+			"resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
+			"integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
+			"dev": true,
+			"requires": {
+				"ast-types": "0.10.1",
+				"core-js": "2.5.3",
+				"esprima": "4.0.0",
+				"private": "0.1.8",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dev": true,
+			"requires": {
+				"resolve": "1.5.0"
+			}
+		},
+		"reduce-css-calc": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
+			"dev": true,
+			"requires": {
+				"balanced-match": "0.4.2",
+				"math-expression-evaluator": "1.2.17",
+				"reduce-function-call": "1.0.2"
+			}
+		},
+		"reduce-function-call": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
+			"dev": true,
+			"requires": {
+				"balanced-match": "0.4.2"
 			}
 		},
 		"regenerate": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
 			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+			"dev": true
+		},
+		"regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
 			"dev": true
 		},
 		"regex-cache": {
@@ -2018,17 +6502,96 @@
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
 		},
+		"require-from-string": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+			"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+			"dev": true
+		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
 			"dev": true
 		},
+		"resolve": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+			"dev": true,
+			"requires": {
+				"path-parse": "1.0.5"
+			}
+		},
+		"rgb": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/rgb/-/rgb-0.1.0.tgz",
+			"integrity": "sha1-vieykej+/+rBvZlylyG/pA/AN7U=",
+			"dev": true
+		},
+		"rgb-hex": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/rgb-hex/-/rgb-hex-2.1.0.tgz",
+			"integrity": "sha1-x3PF/iJoolV42SU5qCp6XOU77aY=",
+			"dev": true
+		},
+		"right-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"dev": true,
+			"requires": {
+				"align-text": "0.1.4"
+			}
+		},
+		"rimraf": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"dev": true,
+			"requires": {
+				"glob": "7.1.2"
+			}
+		},
+		"ripemd160": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+			"dev": true,
+			"requires": {
+				"hash-base": "2.0.2",
+				"inherits": "2.0.3"
+			}
+		},
+		"run-queue": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+			"dev": true,
+			"requires": {
+				"aproba": "1.2.0"
+			}
+		},
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
 			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
 			"dev": true
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
+		},
+		"schema-utils": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+			"integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+			"dev": true,
+			"requires": {
+				"ajv": "5.5.2"
+			}
 		},
 		"semver": {
 			"version": "5.5.0",
@@ -2048,6 +6611,22 @@
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
 			"dev": true
 		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true
+		},
+		"sha.js": {
+			"version": "2.4.10",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
+			"integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
+			}
+		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -2063,10 +6642,70 @@
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
 		},
+		"shelljs": {
+			"version": "0.7.8",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+			"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+			"dev": true,
+			"requires": {
+				"glob": "7.1.2",
+				"interpret": "1.1.0",
+				"rechoir": "0.6.2"
+			}
+		},
+		"shx": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/shx/-/shx-0.2.2.tgz",
+			"integrity": "sha1-CjBNAgsO3xMGrYFXDoDwNG31ijk=",
+			"dev": true,
+			"requires": {
+				"es6-object-assign": "1.1.0",
+				"minimist": "1.2.0",
+				"shelljs": "0.7.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
+			}
+		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
+		},
+		"simple-swizzle": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+			"dev": true,
+			"requires": {
+				"is-arrayish": "0.3.1"
+			}
+		},
+		"slash": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
+		},
+		"sort-keys": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+			"dev": true,
+			"requires": {
+				"is-plain-obj": "1.1.0"
+			}
+		},
+		"source-list-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
 			"dev": true
 		},
 		"source-map": {
@@ -2094,6 +6733,66 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
 			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+			"dev": true
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"ssri": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.2.1.tgz",
+			"integrity": "sha512-y4PjOWlAuxt+yAcXitQYOnOzZpKaH3+f/qGV3OWxbyC2noC9FA9GNC9uILnVdV7jruA1aDKr4OKz3ZDBcVZwFQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"stream-browserify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.4"
+			}
+		},
+		"stream-each": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+			"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"stream-shift": "1.0.0"
+			}
+		},
+		"stream-http": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
+			"integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
+			"dev": true,
+			"requires": {
+				"builtin-status-codes": "3.0.0",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.4",
+				"to-arraybuffer": "1.0.1",
+				"xtend": "4.0.1"
+			}
+		},
+		"stream-shift": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+			"dev": true
+		},
+		"strict-uri-encode": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
 			"dev": true
 		},
 		"string-width": {
@@ -2159,14 +6858,128 @@
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true
 		},
-		"supports-color": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-			"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+		"style-loader": {
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.19.0.tgz",
+			"integrity": "sha512-9mx9sC9nX1dgP96MZOODpGC6l1RzQBITI2D5WJhu+wnbrSYVKLGuy14XJSLVQih/0GFrPpjelt+s//VcZQ2Evw==",
 			"dev": true,
 			"requires": {
-				"has-flag": "2.0.0"
+				"loader-utils": "1.1.0",
+				"schema-utils": "0.3.0"
 			}
+		},
+		"supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
+		},
+		"svgo": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+			"integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+			"dev": true,
+			"requires": {
+				"coa": "1.0.4",
+				"colors": "1.1.2",
+				"csso": "2.3.2",
+				"js-yaml": "3.7.0",
+				"mkdirp": "0.5.1",
+				"sax": "1.2.4",
+				"whet.extend": "0.9.9"
+			}
+		},
+		"tapable": {
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
+			"integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
+			"dev": true
+		},
+		"through2": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.4",
+				"xtend": "4.0.1"
+			}
+		},
+		"timers-browserify": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
+			"integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
+			"dev": true,
+			"requires": {
+				"setimmediate": "1.0.5"
+			}
+		},
+		"to-arraybuffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+			"dev": true
+		},
+		"ts-loader": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-3.1.1.tgz",
+			"integrity": "sha512-AQmLFSIgTiR8AlS5BxqvoHpZ3OUTwHHuDZTAZ2KcKsYRz/yANGeQn4Se/DCQ4cn1/eVvN37f/caVW4+kUPNNHw==",
+			"dev": true,
+			"requires": {
+				"chalk": "2.3.1",
+				"enhanced-resolve": "3.4.1",
+				"loader-utils": "1.1.0",
+				"semver": "5.5.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"tslib": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+			"dev": true
+		},
+		"tty-browserify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+			"dev": true
 		},
 		"typed-css-modules": {
 			"version": "0.3.1",
@@ -2175,13 +6988,194 @@
 			"dev": true,
 			"requires": {
 				"camelcase": "4.1.0",
-				"chalk": "2.3.0",
+				"chalk": "2.3.1",
 				"chokidar": "1.7.0",
 				"css-modules-loader-core": "1.1.0",
 				"glob": "7.1.2",
 				"is-there": "4.4.3",
 				"mkdirp": "0.5.1",
 				"yargs": "8.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.2.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
+		},
+		"typescript": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+			"integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+			"dev": true
+		},
+		"uglify-es": {
+			"version": "3.3.10",
+			"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.10.tgz",
+			"integrity": "sha512-rPzPisCzW68Okj1zNrfa2dR9uEm43SevDmpR6FChoZABFk9dANGnzzBMgHYUXI3609//63fnVkyQ1SQmAMyjww==",
+			"dev": true,
+			"requires": {
+				"commander": "2.14.1",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"uglify-to-browserify": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"dev": true,
+			"optional": true
+		},
+		"uglifyjs-webpack-plugin": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.1.0.tgz",
+			"integrity": "sha512-x5+BK4OvEZZvaoXln/Z1JMGq3Nvp5A8d7oQ7Xpyf17lqZV9NYvugfj5aTaYcxDWNoILgVdnlPWNpAWgVdwT1/g==",
+			"dev": true,
+			"requires": {
+				"cacache": "10.0.2",
+				"find-cache-dir": "1.0.0",
+				"schema-utils": "0.3.0",
+				"source-map": "0.6.1",
+				"uglify-es": "3.3.10",
+				"webpack-sources": "1.1.0",
+				"worker-farm": "1.5.2"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"uniq": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+			"dev": true
+		},
+		"uniqid": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
+			"integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
+			"dev": true,
+			"requires": {
+				"macaddress": "0.2.8"
+			}
+		},
+		"uniqs": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+			"dev": true
+		},
+		"unique-filename": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+			"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+			"dev": true,
+			"requires": {
+				"unique-slug": "2.0.0"
+			}
+		},
+		"unique-slug": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+			"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+			"dev": true,
+			"requires": {
+				"imurmurhash": "0.1.4"
+			}
+		},
+		"units-css": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/units-css/-/units-css-0.4.0.tgz",
+			"integrity": "sha1-1iKGU6UZg9fBb/KPi53Dsf/tOgc=",
+			"dev": true,
+			"requires": {
+				"isnumeric": "0.2.0",
+				"viewport-dimensions": "0.2.0"
+			}
+		},
+		"url": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+			"dev": true,
+			"requires": {
+				"punycode": "1.3.2",
+				"querystring": "0.2.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+					"dev": true
+				}
+			}
+		},
+		"util": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.1"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+					"dev": true
+				}
 			}
 		},
 		"util-deprecate": {
@@ -2200,6 +7194,162 @@
 				"spdx-expression-parse": "1.0.4"
 			}
 		},
+		"vendors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
+			"integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI=",
+			"dev": true
+		},
+		"viewport-dimensions": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz",
+			"integrity": "sha1-3nQHR9tTh/0XJfUXXpG6x2r982w=",
+			"dev": true
+		},
+		"vm-browserify": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+			"dev": true,
+			"requires": {
+				"indexof": "0.0.1"
+			}
+		},
+		"watchpack": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
+			"integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
+			"dev": true,
+			"requires": {
+				"async": "2.6.0",
+				"chokidar": "1.7.0",
+				"graceful-fs": "4.1.11"
+			}
+		},
+		"webpack": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
+			"integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
+			"dev": true,
+			"requires": {
+				"acorn": "5.4.1",
+				"acorn-dynamic-import": "2.0.2",
+				"ajv": "5.5.2",
+				"ajv-keywords": "2.1.1",
+				"async": "2.6.0",
+				"enhanced-resolve": "3.4.1",
+				"escope": "3.6.0",
+				"interpret": "1.1.0",
+				"json-loader": "0.5.7",
+				"json5": "0.5.1",
+				"loader-runner": "2.3.0",
+				"loader-utils": "1.1.0",
+				"memory-fs": "0.4.1",
+				"mkdirp": "0.5.1",
+				"node-libs-browser": "2.1.0",
+				"source-map": "0.5.7",
+				"supports-color": "4.5.0",
+				"tapable": "0.2.8",
+				"uglifyjs-webpack-plugin": "0.4.6",
+				"watchpack": "1.4.0",
+				"webpack-sources": "1.1.0",
+				"yargs": "8.0.2"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+					"dev": true
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+					"dev": true,
+					"requires": {
+						"center-align": "0.1.3",
+						"right-align": "0.1.3",
+						"wordwrap": "0.0.2"
+					}
+				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"dev": true,
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				},
+				"uglify-js": {
+					"version": "2.8.29",
+					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+					"dev": true,
+					"requires": {
+						"source-map": "0.5.7",
+						"uglify-to-browserify": "1.0.2",
+						"yargs": "3.10.0"
+					},
+					"dependencies": {
+						"yargs": {
+							"version": "3.10.0",
+							"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+							"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+							"dev": true,
+							"requires": {
+								"camelcase": "1.2.1",
+								"cliui": "2.1.0",
+								"decamelize": "1.2.0",
+								"window-size": "0.1.0"
+							}
+						}
+					}
+				},
+				"uglifyjs-webpack-plugin": {
+					"version": "0.4.6",
+					"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
+					"integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+					"dev": true,
+					"requires": {
+						"source-map": "0.5.7",
+						"uglify-js": "2.8.29",
+						"webpack-sources": "1.1.0"
+					}
+				}
+			}
+		},
+		"webpack-sources": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+			"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+			"dev": true,
+			"requires": {
+				"source-list-map": "2.0.0",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"whet.extend": {
+			"version": "0.9.9",
+			"resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+			"integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
+			"dev": true
+		},
 		"which": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
@@ -2214,6 +7364,28 @@
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
+		},
+		"window-size": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+			"dev": true
+		},
+		"wordwrap": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+			"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+			"dev": true
+		},
+		"worker-farm": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
+			"integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
+			"dev": true,
+			"requires": {
+				"errno": "0.1.6",
+				"xtend": "4.0.1"
+			}
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
@@ -2242,6 +7414,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
 			"dev": true
 		},
 		"y18n": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"build-watch": "tcm dojo -p *.m.css -w"
 	},
 	"devDependencies": {
-		"@dojo/webpack-contrib": "0.1.6",
+		"@dojo/webpack-contrib": "~0.2.0",
 		"css-loader": "0.28.7",
 		"extract-text-webpack-plugin": "3.0.2",
 		"file-loader": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -17,11 +17,26 @@
 		"url": "https://github.com/dojo/themes.git"
 	},
 	"scripts": {
-		"build": "tcm dojo -p *.m.css",
+		"build": "tcm dojo -p *.m.css && shx rm -r dist && webpack --config webpack.config.js",
 		"build-watch": "tcm dojo -p *.m.css -w"
 	},
 	"devDependencies": {
-		"typed-css-modules": "0.3.1"
-	},
-	"dependencies": {}
+		"@dojo/webpack-contrib": "0.1.6",
+		"css-loader": "0.28.7",
+		"extract-text-webpack-plugin": "3.0.2",
+		"file-loader": "1.1.5",
+		"imports-loader": "0.7.1",
+		"json-css-module-loader": "^1.0.2",
+		"postcss-cssnext": "3.0.2",
+		"postcss-import": "11.0.0",
+		"postcss-loader": "1.0.0",
+		"shx": "^0.2.2",
+		"slash": "^1.0.0",
+		"style-loader": "0.19.0",
+		"ts-loader": "3.1.1",
+		"typed-css-modules": "0.3.1",
+		"typescript": "2.6.2",
+		"uglifyjs-webpack-plugin": "1.1.0",
+		"webpack": "3.8.1"
+	}
 }

--- a/template/theme-installer.js
+++ b/template/theme-installer.js
@@ -1,0 +1,32 @@
+var theme = theme.default;
+var _theme;
+
+if (theme) {
+	if (!window.dojoce) {
+		window.dojoce = {};
+	}
+
+	if (!window.dojoce.themes) {
+		window.dojoce.themes = {};
+	}
+
+	if (!window.dojoce.theme) {
+		Object.defineProperty(window.dojoce, 'theme', {
+			set: function(value) {
+				if (value === window.dojo.theme) {
+					return;
+				}
+				if (window.dojo.themes[value]) {
+					window.dispatchEvent(new CustomEvent('dojo-theme-set', {}));
+					_theme = value;
+				}
+			},
+			get: function() {
+				return _theme;
+			}
+		});
+	}
+
+	window.dojoce.themes[THEME_NAME] = theme;
+	window.dojoce.theme = THEME_NAME;
+}

--- a/template/theme-installer.js
+++ b/template/theme-installer.js
@@ -1,5 +1,4 @@
 var theme = theme.default;
-var _theme;
 
 if (theme) {
 	if (!window.dojoce) {
@@ -7,26 +6,29 @@ if (theme) {
 	}
 
 	if (!window.dojoce.themes) {
-		window.dojoce.themes = {};
+		window.dojoce.themes = {
+			noTheme: {}
+		};
 	}
+
+	window.dojoce.themes[THEME_NAME] = theme;
 
 	if (!window.dojoce.theme) {
 		Object.defineProperty(window.dojoce, 'theme', {
 			set: function(value) {
-				if (value === window.dojo.theme) {
+				value = value === '' ? 'noTheme' : value;
+				if (value === window.dojoce.theme) {
 					return;
 				}
-				if (window.dojo.themes[value]) {
+				if (window.dojoce.themes[value]) {
+					window.dojoce._theme = value;
 					window.dispatchEvent(new CustomEvent('dojo-theme-set', {}));
-					_theme = value;
 				}
 			},
 			get: function() {
-				return _theme;
+				return window.dojoce._theme;
 			}
 		});
 	}
-
-	window.dojoce.themes[THEME_NAME] = theme;
 	window.dojoce.theme = THEME_NAME;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"version": "2.1.5",
+	"compilerOptions": {
+		"declaration": false,
+		"lib": [
+			"dom",
+			"es5",
+			"es2015.iterable",
+			"es2015.promise",
+			"es2015.symbol",
+			"es2015.symbol.wellknown"
+		],
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"importHelpers": true,
+		"downlevelIteration": true,
+		"removeComments": false,
+		"sourceMap": true,
+		"strict": true,
+		"target": "es5"
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,81 +14,81 @@ const packageName = packageJson.name || '';
 const allPaths = path.join(__dirname, 'dojo');
 
 function webpackConfigFactory(args) {
-    const config = {
-        entry: {
-            'main': `imports-loader?theme=${path.join(allPaths, 'index.ts')}!${path.join(__dirname, 'template', 'theme-installer.js')}`
-        },
-        output: {
-            filename: "[name]-" + packageJson.version + ".js",
-            path: path.resolve('./dist/dojo')
-        },
-        resolve: {
-            modules: [basePath, path.join(basePath, 'node_modules')],
-            extensions: ['.ts', '.js']
-        },
-        devtool: 'source-map',
-        plugins: [
-            new CssModulePlugin.default(basePath),
+	const config = {
+		entry: {
+			'main': `imports-loader?theme=${path.join(allPaths, 'index.ts')}!${path.join(__dirname, 'template', 'theme-installer.js')}`
+		},
+		output: {
+			filename: "[name]-" + packageJson.version + ".js",
+			path: path.resolve('./dist/dojo')
+		},
+		resolve: {
+			modules: [basePath, path.join(basePath, 'node_modules')],
+			extensions: ['.ts', '.js']
+		},
+		devtool: 'source-map',
+		plugins: [
+			new CssModulePlugin.default(basePath),
 			new webpack.DefinePlugin({ THEME_NAME: JSON.stringify('dojo') }),
 			new UglifyJsPlugin({ sourceMap: true, cache: true }),
-            new ExtractTextPlugin({
-                filename: function (getPath) { return getPath("[name]-" + packageJson.version + ".css"); }
-            })
-        ],
-        module: {
-            rules: [
-                {
-                    include: allPaths,
-                    test: /.*\.ts?$/,
-                    use: [
-                        {
-                            loader: 'ts-loader',
-                            options: { instance: 'dojo' }
-                        }
-                    ]
-                },
-                {
-                    test: /.*\.(gif|png|jpe?g|svg|eot|ttf|woff|woff2)$/i,
-                    loader: 'file-loader?hash=sha512&digest=hex&name=[hash:base64:8].[ext]'
-                },
-                {
-                    include: allPaths,
-                    test: /.*\.css?$/,
-                    use: ExtractTextPlugin.extract({
-                        fallback: ['style-loader'],
-                        use: [
-                            '@dojo/webpack-contrib/css-module-decorator-loader',
-                            {
-                                loader: 'css-loader',
-                                options: {
-                                    modules: true,
-                                    sourceMap: true,
-                                    importLoaders: 1,
-                                    localIdentName: '[name]__[local]__[hash:base64:5]'
-                                }
-                            },
-                            {
-                                loader: 'postcss-loader?sourceMap',
-                                options: {
-                                    ident: 'postcss',
-                                    plugins: [
-                                        require('postcss-import')(),
-                                        require('postcss-cssnext')({
-                                            features: {
-                                                autoprefixer: {
-                                                    browsers: ['last 2 versions', 'ie >= 10']
-                                                }
-                                            }
-                                        })
-                                    ]
-                                }
-                            }
-                        ]
-                    })
-                }
-            ]
-        }
-    };
-    return config;
+			new ExtractTextPlugin({
+				filename: function (getPath) { return getPath("[name]-" + packageJson.version + ".css"); }
+			})
+		],
+		module: {
+			rules: [
+				{
+					include: allPaths,
+					test: /.*\.ts?$/,
+					use: [
+						{
+							loader: 'ts-loader',
+							options: { instance: 'dojo' }
+						}
+					]
+				},
+				{
+					test: /.*\.(gif|png|jpe?g|svg|eot|ttf|woff|woff2)$/i,
+					loader: 'file-loader?hash=sha512&digest=hex&name=[hash:base64:8].[ext]'
+				},
+				{
+					include: allPaths,
+					test: /.*\.css?$/,
+					use: ExtractTextPlugin.extract({
+						fallback: ['style-loader'],
+						use: [
+							'@dojo/webpack-contrib/css-module-decorator-loader',
+							{
+								loader: 'css-loader',
+								options: {
+									modules: true,
+									sourceMap: true,
+									importLoaders: 1,
+									localIdentName: '[name]__[local]__[hash:base64:5]'
+								}
+							},
+							{
+								loader: 'postcss-loader?sourceMap',
+								options: {
+									ident: 'postcss',
+									plugins: [
+										require('postcss-import')(),
+										require('postcss-cssnext')({
+											features: {
+												autoprefixer: {
+													browsers: ['last 2 versions', 'ie >= 10']
+												}
+											}
+										})
+									]
+								}
+							}
+						]
+					})
+				}
+			]
+		}
+	};
+	return config;
 }
 exports.default = webpackConfigFactory;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,94 @@
+const webpack = require('webpack');
+const CssModulePlugin = require("@dojo/webpack-contrib/css-module-plugin/CssModulePlugin");
+const ExtractTextPlugin = require("extract-text-webpack-plugin");
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const path = require("path");
+const fs = require("fs");
+const loaderUtils = require("loader-utils");
+const slash = require('slash');
+
+const basePath = process.cwd();
+const packageJsonPath = path.join(basePath, 'package.json');
+const packageJson = fs.existsSync(packageJsonPath) ? require(packageJsonPath) : {};
+const packageName = packageJson.name || '';
+const allPaths = path.join(__dirname, 'dojo');
+
+function webpackConfigFactory(args) {
+    const config = {
+        entry: {
+            'main': `imports-loader?theme=${path.join(allPaths, 'index.ts')}!${path.join(__dirname, 'template', 'theme-installer.js')}`
+        },
+        output: {
+            filename: "[name]-" + packageJson.version + ".js",
+            path: path.resolve('./dist/dojo')
+        },
+        resolve: {
+            modules: [basePath, path.join(basePath, 'node_modules')],
+            extensions: ['.ts', '.js']
+        },
+        devtool: 'source-map',
+        plugins: [
+            new CssModulePlugin.default(basePath),
+			new webpack.DefinePlugin({ THEME_NAME: JSON.stringify('dojo') }),
+			new UglifyJsPlugin({ sourceMap: true, cache: true }),
+            new ExtractTextPlugin({
+                filename: function (getPath) { return getPath("[name]-" + packageJson.version + ".css"); }
+            })
+        ],
+        module: {
+            rules: [
+                {
+                    include: allPaths,
+                    test: /.*\.ts?$/,
+                    use: [
+                        {
+                            loader: 'ts-loader',
+                            options: { instance: 'dojo' }
+                        }
+                    ]
+                },
+                {
+                    test: /.*\.(gif|png|jpe?g|svg|eot|ttf|woff|woff2)$/i,
+                    loader: 'file-loader?hash=sha512&digest=hex&name=[hash:base64:8].[ext]'
+                },
+                {
+                    include: allPaths,
+                    test: /.*\.css?$/,
+                    use: ExtractTextPlugin.extract({
+                        fallback: ['style-loader'],
+                        use: [
+                            '@dojo/webpack-contrib/css-module-decorator-loader',
+                            {
+                                loader: 'css-loader',
+                                options: {
+                                    modules: true,
+                                    sourceMap: true,
+                                    importLoaders: 1,
+                                    localIdentName: '[name]__[local]__[hash:base64:5]'
+                                }
+                            },
+                            {
+                                loader: 'postcss-loader?sourceMap',
+                                options: {
+                                    ident: 'postcss',
+                                    plugins: [
+                                        require('postcss-import')(),
+                                        require('postcss-cssnext')({
+                                            features: {
+                                                autoprefixer: {
+                                                    browsers: ['last 2 versions', 'ie >= 10']
+                                                }
+                                            }
+                                        })
+                                    ]
+                                }
+                            }
+                        ]
+                    })
+                }
+            ]
+        }
+    };
+    return config;
+}
+exports.default = webpackConfigFactory;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ const allPaths = path.join(__dirname, 'dojo');
 function webpackConfigFactory(args) {
 	const config = {
 		entry: {
-			'main': `imports-loader?theme=${path.join(allPaths, 'index.ts')}!${path.join(__dirname, 'template', 'theme-installer.js')}`
+			'dojo': `imports-loader?theme=${path.join(allPaths, 'index.ts')}!${path.join(__dirname, 'template', 'theme-installer.js')}`
 		},
 		output: {
 			filename: "[name]-" + packageJson.version + ".js",


### PR DESCRIPTION
We need to build the themes (currently only `dojo`) using webpack so that it can be injected and used by custom elements.

Currently has a local webpack config to build the one theme - we'll need to add support in the `cli` for a command to build themes at which point it can be switched out to use that.