### PR TITLE
rename composes using text-input

### DIFF
--- a/dojo/enhanced-text-input.m.css
+++ b/dojo/enhanced-text-input.m.css
@@ -20,7 +20,7 @@
 }
 
 .input {
-	composes: input from './textinput.m.css';
+	composes: input from './text-input.m.css';
 	flex: 1 1 auto;
 }
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/dojo/themes.git"
 	},
 	"scripts": {
-		"build": "tcm dojo -p *.m.css && shx rm -r dist && webpack --config webpack.config.js",
+		"build": "tcm dojo -p *.m.css && shx rm -rf dist && webpack --config webpack.config.js",
 		"build-watch": "tcm dojo -p *.m.css -w"
 	},
 	"devDependencies": {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Rename reference to old `text-input` name in composes usage.
