### PR TITLE
Add content transition class and min-height for `title-pane`

### DIFF
--- a/dojo/title-pane.m.css
+++ b/dojo/title-pane.m.css
@@ -6,6 +6,7 @@
 	font-size: var(--font-size-base);
 	line-height: var(--line-height-base);
 	overflow: hidden;
+	min-height: calc(var(--font-size-title) + 2 * var(--grid-base));
 }
 
 .root * {
@@ -40,6 +41,9 @@
 	border-left: var(--border-width) solid var(--color-border);
 	border-right: var(--border-width) solid var(--color-border);
 	padding: var(--grid-base);
+}
+
+.contentTransition {
 	transition: margin-top ease-in-out var(--transition-duration);
 }
 


### PR DESCRIPTION
**Type:** feature
<!-- delete one -->

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds theme classes to go with https://github.com/dojo/widgets/pull/520
