### PR TITLE
Hover and focus styles include text-input addons

### DIFF
--- a/dojo/enhanced-text-input.m.css
+++ b/dojo/enhanced-text-input.m.css
@@ -9,6 +9,7 @@
 	font-size: inherit;
 	line-height: var(--line-height-base);
 	padding: var(--grid-base);
+	transition: border var(--transition-duration) var(--transition-easing);
 }
 
 .addonAfter {
@@ -25,5 +26,20 @@
 }
 
 .inputWrapper {
+	composes: inputWrapper from './text-input.m.css';
 	display: flex;
+}
+
+/* focus styles */
+.focused .inputWrapper {
+	box-shadow: var(--box-shadow-dimensions-small) color(var(--color-highlight) alpha(20%));
+}
+
+.input:focus {
+	border-left-color: var(--color-border);
+	box-shadow: none;
+}
+
+.focused .addon {
+	border-color: var(--color-highlight);
 }

--- a/dojo/index.ts
+++ b/dojo/index.ts
@@ -3,7 +3,6 @@ import * as button from './button.m.css';
 import * as calendar from './calendar.m.css';
 import * as checkbox from './checkbox.m.css';
 import * as combobox from './combobox.m.css';
-import * as enhancedTextInput from './enhanced-text-input.m.css';
 import * as dialog from './dialog.m.css';
 import * as icon from './icon.m.css';
 import * as label from './label.m.css';
@@ -17,6 +16,7 @@ import * as splitPane from './split-pane.m.css';
 import * as tabController from './tab-controller.m.css';
 import * as textArea from './text-area.m.css';
 import * as textInput from './text-input.m.css';
+import * as enhancedTextInput from './enhanced-text-input.m.css';
 import * as timePicker from './time-picker.m.css';
 import * as titlePane from './title-pane.m.css';
 import * as toolbar from './toolbar.m.css';
@@ -28,7 +28,6 @@ export default {
 	'@dojo/widgets/calendar': calendar,
 	'@dojo/widgets/checkbox': checkbox,
 	'@dojo/widgets/combobox': combobox,
-	'@dojo/widgets/enhanced-text-input': enhancedTextInput,
 	'@dojo/widgets/dialog': dialog,
 	'@dojo/widgets/icon': icon,
 	'@dojo/widgets/label': label,
@@ -42,6 +41,7 @@ export default {
 	'@dojo/widgets/tab-controller': tabController,
 	'@dojo/widgets/text-area': textArea,
 	'@dojo/widgets/text-input': textInput,
+	'@dojo/widgets/enhanced-text-input': enhancedTextInput,
 	'@dojo/widgets/time-picker': timePicker,
 	'@dojo/widgets/title-pane': titlePane,
 	'@dojo/widgets/toolbar': toolbar,

--- a/dojo/text-input.m.css
+++ b/dojo/text-input.m.css
@@ -27,11 +27,15 @@
 	outline: none;
 }
 
-.input:hover {
-	box-shadow: var(--box-shadow-dimensions-small) color(var(--color-box-shadow));
+.input::placeholder { color: var(--color-text-faded); }
+
+.inputWrapper {
+	transition: box-shadow var(--transition-duration) var(--transition-easing);
 }
 
-.input::placeholder { color: var(--color-text-faded); }
+.inputWrapper:hover {
+	box-shadow: var(--box-shadow-dimensions-small) color(var(--color-box-shadow));
+}
 
 /* disabled and readonly */
 .disabled .input,

--- a/dojo/widgets.css
+++ b/dojo/widgets.css
@@ -3,7 +3,6 @@
 @import './calendar.m.css';
 @import './checkbox.m.css';
 @import './combobox.m.css';
-@import './enhanced-text-input.m.css';
 @import './dialog.m.css';
 @import './icon.m.css';
 @import './label.m.css';
@@ -17,6 +16,7 @@
 @import './tab-controller.m.css';
 @import './text-area.m.css';
 @import './text-input.m.css';
+@import './enhanced-text-input.m.css';
 @import './time-picker.m.css';
 @import './title-pane.m.css';
 @import './toolbar.m.css';


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue

**Description:**

Resolves https://github.com/dojo/widgets/issues/458 from @dojo/widgets

Also reorders theme import of `enhanced-text-input` so it can override inherited `text-input` theme styles.
