### PR TITLE
Use relative path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,7 +73,7 @@ function webpackConfigFactory(args) {
 					loader: 'file-loader?hash=sha512&digest=hex&name=[hash:base64:8].[ext]',
 					options: {
 						outputPath: 'fonts/',
-						publicPath: '/fonts/'
+						useRelativePath: true
 					}
 				},
 				{


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Ensure that the fonts path is correct, and relative.