### PR TITLE
release scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "copy:raw": "run-s copy:raw:**",
     "dojo-package": "dojo-package",
     "dojo-release": "dojo-release",
-    "release": "run-s build dojo-package \"dojo-release -- {@}\" --",
+    "version:release": "node scripts/version",
+    "version:reset": "node scripts/reset",
+    "release": "run-s \"version:release -- {@}\" build version:reset dojo-package --",
     "watch": "tcm dojo -p *.m.css -w"
   },
   "devDependencies": {

--- a/scripts/reset.js
+++ b/scripts/reset.js
@@ -3,4 +3,3 @@ const scripts = require('@dojo/scripts/utils/process');
 (async function() {
 	await scripts.runAsPromise('git', ['checkout', 'package.json', 'package-lock.json'], {});
 })();
-

--- a/scripts/reset.js
+++ b/scripts/reset.js
@@ -1,0 +1,6 @@
+const scripts = require('@dojo/scripts/utils/process');
+
+(async function() {
+	await scripts.runAsPromise('git', ['checkout', 'package.json', 'package-lock.json'], {});
+})();
+

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,0 +1,17 @@
+const scripts = require('@dojo/scripts/utils/process');
+
+let release = null;
+
+process.argv.forEach((arg) => {
+	if (arg.indexOf('--release') !== -1) {
+		release = arg.split('=')[1];
+	}
+});
+
+if (!release) {
+	throw new Error('No release found');
+}
+
+(async function() {
+	await scripts.runAsPromise('npm', ['version', release, '--no-git-tag-version'], {});
+})();


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

When releasing themes the wrong version number is used to create the custom element bundles - the number cannot be bumped manually because then the release fails in the release command. So this is slight "hack" to bump the version for the build and then reset the package.json and package-lock.json.

Only runs when running the release script.