### PR TITLE
Move color function usage from dojo text input theme

### DIFF
--- a/src/dojo/text-input.m.css
+++ b/src/dojo/text-input.m.css
@@ -24,7 +24,7 @@
 .input:focus {
 	border-color: var(--color-highlight);
 	border-bottom-color: var(--color-highlight);
-	box-shadow: var(--box-shadow-dimensions-small) color(var(--color-highlight) alpha(20%));
+	box-shadow: var(--box-shadow-dimensions-small) var(--box-shadow-focus);
 	outline: none;
 }
 
@@ -35,7 +35,7 @@
 }
 
 .inputWrapper:hover {
-	box-shadow: var(--box-shadow-dimensions-small) color(var(--color-box-shadow));
+	box-shadow: var(--box-shadow-dimensions-small) var(--color-box-shadow);
 }
 
 .input::-ms-clear {
@@ -57,20 +57,20 @@
 
 /* invalid */
 .invalid .input {
-	border-color: color(var(--color-error) saturation(-9%) lightness(+37%));
+	border-color: var(--color-border-invalid);
 	border-bottom-color: var(--color-error);
 }
 
 .invalid .input:focus {
-	box-shadow: var(--box-shadow-dimensions-small) color(var(--color-error) alpha(20%));
+	box-shadow: var(--color-box-shadow-invalid);
 }
 
 /* valid */
 .valid .input {
-	border-color: color(var(--color-success) saturation(-32%) lightness(+55%));
+	border-color: var(--color-border-valid);
 	border-bottom-color: var(--color-success);
 }
 
 .valid .input:focus {
-	box-shadow: var(--box-shadow-dimensions-small) color(var(--color-success) alpha(20%));
+	box-shadow: var(--color-box-shadow-valid);
 }

--- a/src/dojo/variables.css
+++ b/src/dojo/variables.css
@@ -35,8 +35,13 @@
 	--color-background-faded: var(--dojo-light-grey);
 	--color-border: var(--dojo-grey);
 	--color-border-strong: var(--dojo-dark-grey);
+	--color-border-invalid: color(var(--color-error) saturation(-9%) lightness(+37%));
+	--color-border-valid: color(var(--color-success) saturation(-32%) lightness(+55%));
 	--color-box-shadow: color(var(--dojo-black) alpha(20%));
 	--color-box-shadow-strong: color(var(--dojo-black) alpha(50%));
+	--color-box-shadow-focus: color(var(--color-highlight) alpha(20%));
+	--color-box-shadow-invalid: var(--box-shadow-dimensions-small) color(var(--color-error) alpha(20%));
+	--color-box-shadow-valid: var(--box-shadow-dimensions-small) color(var(--color-success) alpha(20%));
 
 	/* Border and shadow */
 	--box-shadow-dimensions-small: 0 2px 2px 0;


### PR DESCRIPTION

**Type:** feature
<!-- delete one -->

To help enable dojo material work and normalise color func usage, this PR moves the color func usage out of dojo text-input.