### PR TITLE
Fix Select taking up space on page when closed

### DIFF
--- a/src/dojo/combobox.m.css
+++ b/src/dojo/combobox.m.css
@@ -52,15 +52,30 @@
 	background-color: var(--color-background);
 	border: var(--border-width) solid var(--color-border);
 	box-shadow: var(--box-shadow-dimensions-small) var(--color-box-shadow);
-	opacity: 0;
+	display: none;
 	position: absolute;
 	transition: all var(--transition-duration) var(--transition-easing);
 	width: 100%;
 }
 
 .open .dropdown {
+	display: block;
+	pointer-events: all;
 	opacity: 1;
 	z-index: var(--zindex-dropdown);
+	animation-name: fadeInOpacity;
+	animation-iteration-count: 1;
+	animation-timing-function: var(--transition-easing);
+	animation-duration: var(--transition-duration);
+}
+
+@keyframes fadeInOpacity {
+	0% {
+		opacity: 0;
+	}
+	100% {
+		opacity: 1;
+	}
 }
 
 .option {

--- a/src/dojo/select.m.css
+++ b/src/dojo/select.m.css
@@ -52,20 +52,30 @@
 
 .dropdown {
 	box-shadow: var(--box-shadow-dimensions-small) var(--color-box-shadow);
-	opacity: 0;
+	display: none;
 	pointer-events: none;
 	position: absolute;
-	transition: opacity var(--transition-duration) var(--transition-easing);
 	width: 100%;
 }
 
-.open {
+.open .dropdown {
+	display: block;
+	pointer-events: all;
+	opacity: 1;
 	z-index: var(--zindex-dropdown);
+	animation-name: fadeInOpacity;
+	animation-iteration-count: 1;
+	animation-timing-function: var(--transition-easing);
+	animation-duration: var(--transition-duration);
 }
 
-.open .dropdown {
-	opacity: 1;
-	pointer-events: all;
+@keyframes fadeInOpacity {
+	0% {
+		opacity: 0;
+	}
+	100% {
+		opacity: 1;
+	}
 }
 
 /* native input styles */


### PR DESCRIPTION
**Type:** bug
<!-- delete one -->

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**
Fixes issue where a closed menu takes up the same space as the open menu due to it using `opacity: 0` instead of `display: none`.
This Fix adds `display: none` and uses a keyframe animation to add back the `fadeIn`.

Fixes: https://github.com/dojo/themes/issues/45
