### PR TITLE
IE 11 Fixes

### DIFF
--- a/src/dojo/dialog.m.css
+++ b/src/dojo/dialog.m.css
@@ -25,6 +25,7 @@
 	top: 50%;
 	transform: translate(-50%, -50%);
 	width: calc(80 * var(--grid-base));
+	z-index: var(--zindex-dialog);
 	z-index: calc(var(--zindex-dialog) + 1);
 }
 

--- a/src/dojo/icon.m.css
+++ b/src/dojo/icon.m.css
@@ -1,7 +1,7 @@
 @import './variables.css';
 
 @font-face {
-  font-family: var(--icon-font-family);
+  font-family: 'dojo2BaseTheme';
   src:
     url('./assets/dojo2BaseTheme.ttf?nocf9g') format('truetype'),
     url('./assets/dojo2BaseTheme.woff?nocf9g') format('woff'),

--- a/src/dojo/icon.m.css
+++ b/src/dojo/icon.m.css
@@ -12,7 +12,7 @@
 
 .icon {
   /* use !important to prevent issues with browser extensions that change fonts */
-  font-family: var(--icon-font-family) !important;
+  font-family: 'dojo2BaseTheme' !important;
   speak: none;
   font-size: inherit;
   font-style: normal;

--- a/src/dojo/listbox.m.css
+++ b/src/dojo/listbox.m.css
@@ -43,7 +43,7 @@
 }
 
 .selectedOption::before {
-	font-family: var(--icon-font-family);
+	font-family: 'dojo2BaseTheme';
 	position: absolute;
 	right: var(--grid-base);
 	top: 50%;

--- a/src/dojo/variables.css
+++ b/src/dojo/variables.css
@@ -11,7 +11,6 @@
 	--font-size-title: 20px;
 	--font-size-icon: 24px;
 	--line-height-base: 24px;
-	--icon-font-family: 'dojo2BaseTheme';
 
 	/* Color hex values */
 	--color-text-primary: #000000;


### PR DESCRIPTION
**Type:** bug
<!-- delete one -->

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Fixing a couple of issues with IE 11.  The `Dialog` component was showing up in line with the underlay, causing it to appear behind everything.

![image](https://user-images.githubusercontent.com/2008858/54631058-925ebf00-4a51-11e9-9436-762ce9a86ca3.png)

Additionally, you may notice in that screenshot that there are no icons.  That's fixed here too! 

![image](https://user-images.githubusercontent.com/2008858/54631032-85da6680-4a51-11e9-9cc1-59fb4bc5a722.png)

