### PR TITLE
Add build and local testing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,3 @@ Variables can be used by using `@import` to import the `variables.css` file from
 	background-color: var(--dojo-green);
 }
 ```
-
-## Generating typings
-
-The following `npm` scripts are available to facilitate development:
-
-- `build:tcm`: generate `.m.css.d.ts` files
-- `watch`: generate `.m.css.d.ts` files in watch mode

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,43 @@
+# Dojo Themes Development
+
+## Building `@dojo/themes`
+
+The `build` script will build `@dojo/themes`:
+
+```sh
+dojo/themes$ npm run build
+```
+
+The build process produces a single optimized build file, e.g. `dist/src/dojo/dojo-5.0.0.css` and also copies all of
+the unbuilt source modules to the `dist` folder.
+
+## Testing themes in the browser
+
+Dojo themes can be tested with the [Widget Showcase](https://github.com/dojo/examples/tree/master/widget-showcase) in
+[`@dojo/examples`](https://github.com/dojo/examples). Local testing can be done by following the steps below:
+
+1. Build `@dojo/themes`:
+
+```sh
+dojo/themes$ npm run build
+dojo/themes$ npm run release:prepare
+dojo/themes$ npm run dojo-package
+```
+
+2. Install the local themes build in `widget-showcase`:
+
+
+```sh
+dojo/examples/widget-showcase$ npm install ../../themes/dist/release
+```
+
+This creates a symlink in `widget-showcase/node_modules` to `../../themes/dist/release`, so on further rebuilds of
+`themes` you don't need to re-run `npm install`.
+
+3. Build `widget-showcase`:
+
+```sh
+dojo/examples/widget-showcase$ npm run build
+```
+
+With an HTTP server running you can open `dojo/examples/widget-showcase/output/dist/index.html` in your browser.


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Add documentation describing how to locally build and test `@dojo/themes` with `@dojo/examples/widget-showcase`.

This PR also removes some incorrect (outdated?) [documentation](https://github.com/dojo/themes/commit/5e50f8946d36b8cc762a69665fdfaa638b3f77b5) from `README.md`: the listed npm scripts do not exist.

Resolves #51
