### PR TITLE
Material theme: add icon support

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@dojo/scripts": "~3.1.0",
     "@material/button": "^2.1.1",
     "cpx": "1.5.0",
+    "material-design-icons": "^3.0.1",
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.2",
     "shx": "0.3.2",

--- a/src/material/icon.m.css
+++ b/src/material/icon.m.css
@@ -1,1 +1,128 @@
-.icon { }
+@font-face {
+	font-family: 'Material Icons';
+	font-style: normal;
+	font-weight: 400;
+	src:
+	local('Material Icons'),
+	local('MaterialIcons-Regular'),
+	url(../../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
+	url(../../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.woff) format('woff'),
+	url(../../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.ttf) format('truetype');
+}
+
+.root {}
+
+.icon {
+	/* use !important to prevent issues with browser extensions that change fonts */
+	font-family: 'Material Icons' !important;
+	font-weight: normal;
+	font-style: normal;
+	font-size: 18px;
+	display: inline-block;
+	line-height: 1;
+	text-transform: none;
+	letter-spacing: normal;
+	word-wrap: normal;
+	white-space: nowrap;
+	direction: ltr;
+	speak: none;
+
+	/* Support for all WebKit browsers. */
+	-webkit-font-smoothing: antialiased;
+	/* Support for Safari and Chrome. */
+	text-rendering: optimizeLegibility;
+	/* Support for Firefox. */
+	-moz-osx-font-smoothing: grayscale;
+}
+
+.downIcon:before {
+	content: 'expand_more';
+}
+
+.leftIcon:before {
+	content: 'chevron_left';
+}
+
+.rightIcon:before {
+	content: 'chevron_right';
+}
+
+.closeIcon:before {
+	content: 'close';
+}
+
+.plusIcon:before {
+	content: 'add';
+}
+
+.minusIcon:before {
+	content: 'remove';
+}
+
+.checkIcon:before {
+	content: 'done';
+}
+
+.upIcon:before {
+	content: 'expand_less';
+}
+
+.upAltIcon:before {
+	content: 'arrow_drop_up';
+}
+
+.downAltIcon:before {
+	content: 'arrow_drop_down';
+}
+
+.searchIcon:before {
+	content: 'search';
+}
+
+.barsIcon:before {
+	content: 'menu';
+}
+
+.settingsIcon:before {
+	content: 'settings';
+}
+
+.alertIcon:before {
+	content: 'error';
+}
+
+.helpIcon:before {
+	content: 'help';
+}
+
+.infoIcon:before {
+	content: 'info';
+}
+
+.phoneIcon:before {
+	content: 'phone';
+}
+
+.editIcon:before {
+	content: 'edit';
+}
+
+.dateIcon:before {
+	content: 'today';
+}
+
+.linkIcon:before {
+	content: 'link';
+}
+
+.locationIcon:before {
+	content: 'location_on';
+}
+
+.secureIcon:before {
+	content: 'lock';
+}
+
+.mailIcon:before {
+	content: 'email';
+}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

* add `material-design-icons` to dev dependencies
* update `src/material/icon.m.css` to load Material Icons font and apply appropriate fonts to icon component CSS classes

Resolves #61
