### PR TITLE
Add material design theme for tab (#83)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@dojo/scripts": "~3.1.0",
     "@material/button": "^2.1.1",
     "@material/radio": "^3.2.0",
+    "@material/tab": "^4.0.0",
     "cpx": "1.5.0",
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.2",

--- a/src/material/tab-controller.m.css
+++ b/src/material/tab-controller.m.css
@@ -1,1 +1,108 @@
-.root { }
+@import './variables.css';
+
+:root {
+	--indicator-width: 2px;
+}
+
+/* TAB BUTTONS */
+.tabButtons {
+	display: flex;
+}
+
+.tabButton {
+	composes: mdc-tab mdc-tab__content from '@material/tab/dist/mdc.tab.css';
+	height: 48px;
+	pointer-events: all;
+}
+
+.tabButtonContent {
+	composes: mdc-tab__text-label from '@material/tab/dist/mdc.tab.css';
+}
+
+.activeTabButton {
+	composes: mdc-tab--active from '@material/tab/dist/mdc.tab.css';
+}
+
+.disabledTabButton {
+	font-style: italic;
+	cursor: default;
+	color: var(--disabled-color);
+}
+
+.close {
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	right: 5px;
+	cursor: pointer;
+	font-size: 0;
+	border: none;
+	background: none;
+	padding: 1px 3px;
+	margin-top: -1px;
+}
+
+.close:after {
+	content: '✕';
+	display: block;
+	font-size: 14px;
+	line-height: 14px;
+}
+
+/* TAB INDICATOR */
+.indicator {
+	composes: mdc-tab-indicator from '@material/tab-indicator/dist/mdc.tab-indicator.css';
+}
+
+.indicatorActive {
+	composes: mdc-tab-indicator--active from '@material/tab-indicator/dist/mdc.tab-indicator.css';
+}
+
+.indicatorContent {
+	composes: mdc-tab-indicator__content mdc-tab-indicator__content--underline from '@material/tab-indicator/dist/mdc.tab-indicator.css';
+}
+
+.indicatorActive .indicatorContent {
+	background-color: var(--primary-inverse);
+}
+
+/* TABS */
+.tab {
+	composes: mdc-tab__content from '@material/tab/dist/mdc.tab.css';
+}
+
+/* OTHER ALIGNMENTS */
+.alignRight,
+.alignLeft {
+	display: flex;
+}
+
+.alignRight .tabButtons,
+.alignLeft .tabButtons {
+	flex-direction: column;
+}
+
+.alignRight .indicatorContent,
+.alignLeft .indicatorContent {
+	border-top-width: 0;
+	height: 100%;
+}
+
+.alignRight .indicatorContent {
+	border-left-width: var(--indicator-width);
+	border-left-style: solid;
+}
+
+.alignLeft .indicatorContent {
+	border-right-width: var(--indicator-width);
+	border-right-style: solid;
+}
+
+.alignRight .tabs,
+.alignLeft .tabs {
+	flex: 1;
+}
+
+.alignBottom .indicatorContent {
+	align-self: flex-start;
+}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**
Material design theme for tab controller & tabs. Supports all existing tab controller alignments. Relies on new markup/classes introduced in dojo/widgets#894

Resolves #83 
