### PR TITLE
Add deprecated warning to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## The `@dojo/themes` repository has been deprecated. Dojo themes have been merged into [`@dojo/widgets`](https://github.com/dojo/widgets).
+
 # Dojo Themes
 
 Package that contains a collection of Dojo themes.


### PR DESCRIPTION
**Type:** feature
<!-- delete one -->

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Themes have been moved to the `dojo/widgets` repository, https://github.com/dojo/widgets/pull/932. Add message to the readme for the deprecation.